### PR TITLE
Fix loading tyrquake from a terminal without full paths

### DIFF
--- a/common/libretro.c
+++ b/common/libretro.c
@@ -679,7 +679,10 @@ static void extract_directory(char *buf, const char *path, size_t size)
    if (base)
       *base = '\0';
    else
-      buf[0] = '\0';
+    {
+       buf[0] = '.';
+       buf[1] = '\0';
+    }
 }
 
 const char *argv[MAX_NUM_ARGVS];


### PR DESCRIPTION
Tyrquake fails to load the pak files or either of the two expansions without full paths.

Does not work:
`retroarch -L /usr/lib64/libretro/tyrquake_libretro.so pak0.pak`
`retroarch -L /usr/lib64/libretro/tyrquake_libretro.so rogue/`
`retroarch -L /usr/lib64/libretro/tyrquake_libretro.so hipnotic/`

Does work:
`retroarch -L /usr/lib64/libretro/tyrquake_libretro.so quake/`
`retroarch -L /usr/lib64/libretro/tyrquake_libretro.so /full/path/to/quake/rogue`
`retroarch -L /usr/lib64/libretro/tyrquake_libretro.so /full/path/to/quake/hipnotic`

This pull request will fix the first 3 examples. It still might be missing something, but its better than nothing. It will still not be able to start the rogue or hipnotic pak files directly which is not really a big problem when `retroarch -L /usr/lib64/libretro/tyrquake_libretro.so rogue/` will work.

This pull request was copy / pasted from a similar one found here...
https://github.com/libretro/libretro-fba/issues/67