### PR TITLE
Quakespasm audio file bgm

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -62,6 +62,16 @@ SOURCES_C :=  \
 	$(CORE_DIR)/common/screen.c \
 	$(CORE_DIR)/common/shell.c \
 	$(CORE_DIR)/common/bgmusic.c \
+    $(CORE_DIR)/common/snd_codec.c \
+    $(CORE_DIR)/common/snd_flac.c \
+    $(CORE_DIR)/common/snd_mikmod.c \
+    $(CORE_DIR)/common/snd_modplug.c \
+    $(CORE_DIR)/common/snd_mp3.c \
+    $(CORE_DIR)/common/snd_mpg123.c \
+    $(CORE_DIR)/common/snd_opus.c \
+    $(CORE_DIR)/common/snd_umx.c \
+    $(CORE_DIR)/common/snd_vorbis.c \
+    $(CORE_DIR)/common/snd_wave.c \
 	$(CORE_DIR)/common/snd_dma.c \
 	$(CORE_DIR)/common/snd_mem.c \
 	$(CORE_DIR)/common/snd_mix.c \

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,6 +61,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/common/sbar.c \
 	$(CORE_DIR)/common/screen.c \
 	$(CORE_DIR)/common/shell.c \
+	$(CORE_DIR)/common/bgmusic.c \
 	$(CORE_DIR)/common/snd_dma.c \
 	$(CORE_DIR)/common/snd_mem.c \
 	$(CORE_DIR)/common/snd_mix.c \

--- a/common/bgmusic.c
+++ b/common/bgmusic.c
@@ -1,0 +1,35 @@
+#include "quakedef.h"
+#include "console.h"
+#include "common.h"
+#include "cmd.h"
+#include "sound.h"
+#include "cdaudio.h"
+
+#include "bgmusic.h"
+
+qboolean BGM_Init (void) {
+    return;
+}
+void BGM_Shutdown (void) {
+    return;
+}
+
+void BGM_Play (const char *filename) {
+    return;
+}
+void BGM_Stop (void) {
+    return;
+}
+void BGM_Update (void) {
+    return;
+}
+void BGM_Pause (void) {
+    return;
+}
+void BGM_Resume (void) {
+    return;
+}
+
+void BGM_PlayCDtrack (byte track, qboolean looping) {
+    return;
+}

--- a/common/bgmusic.c
+++ b/common/bgmusic.c
@@ -1,3 +1,27 @@
+/*
+ * Background music handling for Quakespasm (adapted from uHexen2)
+ * Handles streaming music as raw sound samples and runs the midi driver
+ *
+ * Copyright (C) 1999-2005 Id Software, Inc.
+ * Copyright (C) 2010-2012 O.Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
 #include "quakedef.h"
 #include "console.h"
 #include "common.h"
@@ -5,31 +29,431 @@
 #include "sound.h"
 #include "cdaudio.h"
 
+#include "snd_codec.h"
 #include "bgmusic.h"
 
-qboolean BGM_Init (void) {
-    return;
-}
-void BGM_Shutdown (void) {
-    return;
+#define MUSIC_DIRNAME	"music"
+
+qboolean	bgmloop;
+cvar_t		bgm_extmusic = {"bgm_extmusic", "1", false};
+
+static qboolean	no_extmusic= false;
+static float	old_volume = -1.0f;
+
+typedef enum _bgm_player
+{
+	BGM_NONE = -1,
+	BGM_MIDIDRV = 1,
+	BGM_STREAMER
+} bgm_player_t;
+
+typedef struct music_handler_s
+{
+	unsigned int	type;	/* 1U << n (see snd_codec.h)	*/
+	bgm_player_t	player;	/* Enumerated bgm player type	*/
+	int	is_available;	/* -1 means not present		*/
+	const char	*ext;	/* Expected file extension	*/
+	const char	*dir;	/* Where to look for music file */
+	struct music_handler_s	*next;
+} music_handler_t;
+
+static music_handler_t wanted_handlers[] =
+{
+	{ CODECTYPE_VORBIS,BGM_STREAMER,-1,  "ogg", MUSIC_DIRNAME, NULL },
+	{ CODECTYPE_OPUS, BGM_STREAMER, -1, "opus", MUSIC_DIRNAME, NULL },
+	{ CODECTYPE_MP3,  BGM_STREAMER, -1,  "mp3", MUSIC_DIRNAME, NULL },
+	{ CODECTYPE_FLAC, BGM_STREAMER, -1, "flac", MUSIC_DIRNAME, NULL },
+	{ CODECTYPE_WAV,  BGM_STREAMER, -1,  "wav", MUSIC_DIRNAME, NULL },
+	{ CODECTYPE_MOD,  BGM_STREAMER, -1,  "it",  MUSIC_DIRNAME, NULL },
+	{ CODECTYPE_MOD,  BGM_STREAMER, -1,  "s3m", MUSIC_DIRNAME, NULL },
+	{ CODECTYPE_MOD,  BGM_STREAMER, -1,  "xm",  MUSIC_DIRNAME, NULL },
+	{ CODECTYPE_MOD,  BGM_STREAMER, -1,  "mod", MUSIC_DIRNAME, NULL },
+	{ CODECTYPE_UMX,  BGM_STREAMER, -1,  "umx", MUSIC_DIRNAME, NULL },
+	{ CODECTYPE_NONE, BGM_NONE,     -1,   NULL,         NULL,  NULL }
+};
+
+static music_handler_t *music_handlers = NULL;
+
+#define ANY_CODECTYPE	0xFFFFFFFF
+#define CDRIP_TYPES	(CODECTYPE_VORBIS | CODECTYPE_MP3 | CODECTYPE_FLAC | CODECTYPE_WAV)
+#define CDRIPTYPE(x)	(((x) & CDRIP_TYPES) != 0)
+
+static snd_stream_t *bgmstream = NULL;
+
+static void BGM_Play_f (void)
+{
+	if (Cmd_Argc() == 2)
+	{
+		BGM_Play (Cmd_Argv(1));
+	}
+	else
+	{
+		Con_Printf ("music <musicfile>\n");
+		return;
+	}
 }
 
-void BGM_Play (const char *filename) {
-    return;
-}
-void BGM_Stop (void) {
-    return;
-}
-void BGM_Update (void) {
-    return;
-}
-void BGM_Pause (void) {
-    return;
-}
-void BGM_Resume (void) {
-    return;
+static void BGM_Pause_f (void)
+{
+	BGM_Pause ();
 }
 
-void BGM_PlayCDtrack (byte track, qboolean looping) {
-    return;
+static void BGM_Resume_f (void)
+{
+	BGM_Resume ();
 }
+
+static void BGM_Loop_f (void)
+{
+	if (Cmd_Argc() == 2)
+	{
+		if (strcasecmp(Cmd_Argv(1),  "0") == 0 ||
+		    strcasecmp(Cmd_Argv(1),"off") == 0)
+			bgmloop = false;
+		else if (strcasecmp(Cmd_Argv(1), "1") == 0 ||
+		         strcasecmp(Cmd_Argv(1),"on") == 0)
+			bgmloop = true;
+		else if (strcasecmp(Cmd_Argv(1),"toggle") == 0)
+			bgmloop = !bgmloop;
+	}
+
+	if (bgmloop)
+		Con_Printf("Music will be looped\n");
+	else
+		Con_Printf("Music will not be looped\n");
+}
+
+static void BGM_Stop_f (void)
+{
+	BGM_Stop();
+}
+
+qboolean BGM_Init (void)
+{
+	music_handler_t *handlers = NULL;
+	int i;
+
+	Cvar_RegisterVariable(&bgm_extmusic);
+	Cmd_AddCommand("music", BGM_Play_f);
+	Cmd_AddCommand("music_pause", BGM_Pause_f);
+	Cmd_AddCommand("music_resume", BGM_Resume_f);
+	Cmd_AddCommand("music_loop", BGM_Loop_f);
+	Cmd_AddCommand("music_stop", BGM_Stop_f);
+
+	if (COM_CheckParm("-noextmusic") != 0)
+		no_extmusic = true;
+
+	bgmloop = true;
+
+	for (i = 0; wanted_handlers[i].type != CODECTYPE_NONE; i++)
+	{
+		switch (wanted_handlers[i].player)
+		{
+		case BGM_MIDIDRV:
+		/* not supported in quake */
+			break;
+		case BGM_STREAMER:
+			wanted_handlers[i].is_available =
+				S_CodecIsAvailable(wanted_handlers[i].type);
+			break;
+		case BGM_NONE:
+		default:
+			break;
+		}
+		if (wanted_handlers[i].is_available != -1)
+		{
+			if (handlers)
+			{
+				handlers->next = &wanted_handlers[i];
+				handlers = handlers->next;
+			}
+			else
+			{
+				music_handlers = &wanted_handlers[i];
+				handlers = music_handlers;
+			}
+		}
+	}
+
+	return true;
+}
+
+void BGM_Shutdown (void)
+{
+	BGM_Stop();
+/* sever our connections to
+ * midi_drv and snd_codec */
+	music_handlers = NULL;
+}
+
+static void BGM_Play_noext (const char *filename, unsigned int allowed_types)
+{
+	char tmp[MAX_QPATH];
+	music_handler_t *handler;
+
+	handler = music_handlers;
+	while (handler)
+	{
+		if (! (handler->type & allowed_types))
+		{
+			handler = handler->next;
+			continue;
+		}
+		if (!handler->is_available)
+		{
+			handler = handler->next;
+			continue;
+		}
+		snprintf(tmp, sizeof(tmp), "%s/%s.%s",
+			   handler->dir, filename, handler->ext);
+		switch (handler->player)
+		{
+		case BGM_MIDIDRV:
+		/* not supported in quake */
+			break;
+		case BGM_STREAMER:
+			bgmstream = S_CodecOpenStreamType(tmp, handler->type);
+			if (bgmstream)
+				return;		/* success */
+			break;
+		case BGM_NONE:
+		default:
+			break;
+		}
+		handler = handler->next;
+	}
+
+	Con_Printf("Couldn't handle music file %s\n", filename);
+}
+
+void BGM_Play (const char *filename)
+{
+	char tmp[MAX_QPATH];
+	const char *ext;
+	music_handler_t *handler;
+
+	BGM_Stop();
+
+	if (music_handlers == NULL)
+		return;
+
+	if (!filename || !*filename)
+	{
+		Con_DPrintf("null music file name\n");
+		return;
+	}
+
+	ext = COM_FileExtension(filename);
+	if (! *ext)	/* try all things */
+	{
+		BGM_Play_noext(filename, ANY_CODECTYPE);
+		return;
+	}
+
+	handler = music_handlers;
+	while (handler)
+	{
+		if (handler->is_available &&
+		    !strcasecmp(ext, handler->ext))
+			break;
+		handler = handler->next;
+	}
+	if (!handler)
+	{
+		Con_Printf("Unhandled extension for %s\n", filename);
+		return;
+	}
+	snprintf(tmp, sizeof(tmp), "%s/%s", handler->dir, filename);
+	switch (handler->player)
+	{
+	case BGM_MIDIDRV:
+	/* not supported in quake */
+		break;
+	case BGM_STREAMER:
+		bgmstream = S_CodecOpenStreamType(tmp, handler->type);
+		if (bgmstream)
+			return;		/* success */
+		break;
+	case BGM_NONE:
+	default:
+		break;
+	}
+
+	Con_Printf("Couldn't handle music file %s\n", filename);
+}
+
+void BGM_PlayCDtrack (byte track, qboolean looping)
+{
+/* instead of searching by the order of music_handlers, do so by
+ * the order of searchpath priority: the file from the searchpath
+ * with the highest path_id is most likely from our own gamedir
+ * itself. This way, if a mod has track02 as a *.mp3 file, which
+ * is below *.ogg in the music_handler order, the mp3 will still
+ * have priority over track02.ogg from, say, id1.
+ */
+	char tmp[MAX_QPATH];
+	const char *ext;
+	unsigned int type;
+	music_handler_t *handler;
+
+
+	BGM_Stop();
+	if (CDAudio_Play(track, looping) == 0)
+		return;			/* success */
+	if (music_handlers == NULL)
+		return;
+	if (no_extmusic || !bgm_extmusic.value)
+		return;
+
+	type = 0;
+	ext  = NULL;
+	handler = music_handlers;
+	while (handler)
+	{
+		if (! handler->is_available)
+			goto _next;
+		if (! CDRIPTYPE(handler->type))
+			goto _next;
+		snprintf(tmp, sizeof(tmp), "%s/track%02d.%s",
+				MUSIC_DIRNAME, (int)track, handler->ext);
+		if (! COM_FileExists(tmp))
+			goto _next;
+		type = handler->type;
+		ext = handler->ext;
+	_next:
+		handler = handler->next;
+	}
+	if (ext == NULL)
+		Con_Printf("Couldn't find a cdrip for track %d\n", (int)track);
+	else
+	{
+		snprintf(tmp, sizeof(tmp), "%s/track%02d.%s",
+				MUSIC_DIRNAME, (int)track, ext);
+		bgmstream = S_CodecOpenStreamType(tmp, type);
+		if (! bgmstream)
+			Con_Printf("Couldn't handle music file %s\n", tmp);
+	}
+}
+
+void BGM_Stop (void)
+{
+	if (bgmstream)
+	{
+		bgmstream->status = STREAM_NONE;
+		S_CodecCloseStream(bgmstream);
+		bgmstream = NULL;
+		s_rawend = 0;
+	}
+}
+
+void BGM_Pause (void)
+{
+	if (bgmstream)
+	{
+		if (bgmstream->status == STREAM_PLAY)
+			bgmstream->status = STREAM_PAUSE;
+	}
+}
+
+void BGM_Resume (void)
+{
+	if (bgmstream)
+	{
+		if (bgmstream->status == STREAM_PAUSE)
+			bgmstream->status = STREAM_PLAY;
+	}
+}
+
+static void BGM_UpdateStream (void)
+{
+	int	res;	/* Number of bytes read. */
+	int	bufferSamples;
+	int	fileSamples;
+	int	fileBytes;
+	byte	raw[16384];
+
+	if (bgmstream->status != STREAM_PLAY)
+		return;
+
+	/* don't bother playing anything if musicvolume is 0 */
+	if (bgmvolume.value <= 0)
+		return;
+
+	/* see how many samples should be copied into the raw buffer */
+	if (s_rawend < paintedtime)
+		s_rawend = paintedtime;
+
+	while (s_rawend < paintedtime + MAX_RAW_SAMPLES)
+	{
+		bufferSamples = MAX_RAW_SAMPLES - (s_rawend - paintedtime);
+
+		/* decide how much data needs to be read from the file */
+		fileSamples = bufferSamples * bgmstream->info.rate / shm->speed;
+		if (!fileSamples)
+			return;
+
+		/* our max buffer size */
+		fileBytes = fileSamples * (bgmstream->info.width * bgmstream->info.channels);
+		if (fileBytes > (int) sizeof(raw))
+		{
+			fileBytes = (int) sizeof(raw);
+			fileSamples = fileBytes /
+					  (bgmstream->info.width * bgmstream->info.channels);
+		}
+
+		/* Read */
+		res = S_CodecReadStream(bgmstream, fileBytes, raw);
+		if (res < fileBytes)
+		{
+			fileBytes = res;
+			fileSamples = res / (bgmstream->info.width * bgmstream->info.channels);
+		}
+
+		if (res > 0)	/* data: add to raw buffer */
+		{
+			S_RawSamples(fileSamples, bgmstream->info.rate,
+							bgmstream->info.width,
+							bgmstream->info.channels,
+							raw, bgmvolume.value);
+		}
+		else if (res == 0)	/* EOF */
+		{
+			if (bgmloop)
+			{
+				res = S_CodecRewindStream(bgmstream);
+				if (res != 0)
+				{
+					Con_Printf("Stream seek error (%i), stopping.\n", res);
+					BGM_Stop();
+					return;
+				}
+			}
+			else
+			{
+				BGM_Stop();
+				return;
+			}
+		}
+		else	/* res < 0: some read error */
+		{
+			Con_Printf("Stream read error (%i), stopping.\n", res);
+			BGM_Stop();
+			return;
+		}
+	}
+}
+
+void BGM_Update (void)
+{
+	if (old_volume != bgmvolume.value)
+	{
+		if (bgmvolume.value < 0)
+			Cvar_Set ("bgmvolume", "0");
+		else if (bgmvolume.value > 1)
+			Cvar_Set ("bgmvolume", "1");
+		old_volume = bgmvolume.value;
+	}
+	if (bgmstream)
+		BGM_UpdateStream ();
+}
+

--- a/common/bgmusic.h
+++ b/common/bgmusic.h
@@ -1,0 +1,43 @@
+/*
+ * Background music handling for Quakespasm (adapted from uHexen2)
+ * Handles streaming music as raw sound samples and runs the midi driver
+ *
+ * Copyright (C) 1999-2005 Id Software, Inc.
+ * Copyright (C) 2010-2012 O.Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef _BGMUSIC_H_
+#define _BGMUSIC_H_
+
+extern qboolean	bgmloop;
+extern cvar_t	bgm_extmusic;
+
+qboolean BGM_Init (void);
+void BGM_Shutdown (void);
+
+void BGM_Play (const char *filename);
+void BGM_Stop (void);
+void BGM_Update (void);
+void BGM_Pause (void);
+void BGM_Resume (void);
+
+void BGM_PlayCDtrack (byte track, qboolean looping);
+
+#endif	/* _BGMUSIC_H_ */
+

--- a/common/cd_common.c
+++ b/common/cd_common.c
@@ -47,22 +47,6 @@ static float cdvolume;
 
 static void CDAudio_SetVolume_f(struct cvar_s *var);
 
-cvar_t bgmvolume = {
-    "bgmvolume",
-    "1",
-    true,
-#ifdef NQ_HACK
-0,
-#endif
-#ifdef QW_HACK
-0,
-#endif
-0,
-    CDAudio_SetVolume_f,
-NULL,
-NULL
-};
-
 static void
 CDAudio_Eject(void)
 {
@@ -164,31 +148,31 @@ CDAudio_Resume(void)
 }
 
 
-void
+int
 CDAudio_Play(byte track, qboolean looping)
 {
     int err;
 
     if (!enabled)
-	return;
+	return -1;
 
     if (!cdValid) {
 	CDAudio_GetAudioDiskInfo();
 	if (!cdValid)
-	    return;
+	    return -1;
     }
     track = remap[track];
     if (track < 1 || track > maxTrack) {
 	Con_DPrintf("CDAudio: Bad track number %u.\n", track);
-	return;
+	return -1;
     }
     if (!CDDrv_IsAudioTrack(track)) {
 	Con_Printf("CDAudio: track %i is not audio\n", track);
-	return;
+	return -1;
     }
     if (playing) {
 	if (playTrack == track)
-	    return;
+	    return -1;
 	CDAudio_Stop();
     }
     err = CDDrv_PlayTrack(track);
@@ -199,6 +183,7 @@ CDAudio_Play(byte track, qboolean looping)
     }
     if (cdvolume == 0.0)
 	CDAudio_Pause();
+    return 0;
 }
 
 void
@@ -348,7 +333,6 @@ CDAudio_Init(void)
 	Con_Printf("CDAudio_Init: No CD in player.\n");
 	cdValid = false;
     }
-    Cvar_RegisterVariable(&bgmvolume);
 
     return 0;
 }

--- a/common/cdaudio.h
+++ b/common/cdaudio.h
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "qtypes.h"
 
 int CDAudio_Init(void);
-void CDAudio_Play(byte track, qboolean looping);
+int CDAudio_Play(byte track, qboolean looping);
 void CDAudio_Stop(void);
 void CDAudio_Pause(void);
 void CDAudio_Resume(void);

--- a/common/cl_main.c
+++ b/common/cl_main.c
@@ -33,6 +33,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "screen.h"
 #include "server.h"
 #include "sound.h"
+#include "bgmusic.h"
+#include "cdaudio.h"
 
 /* we need to declare some mouse variables here, 
  * because the menu system
@@ -144,6 +146,8 @@ void CL_Disconnect(void)
 
    /* stop sounds (especially looping!) */
    S_StopAllSounds(true);
+   BGM_Stop();
+   CDAudio_Stop();
 
    /* Clear up view, remove palette shift */
    scr_centertime_off = 0;

--- a/common/cl_parse.c
+++ b/common/cl_parse.c
@@ -32,6 +32,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "screen.h"
 #include "server.h"
 #include "sound.h"
+#include "bgmusic.h"
 #include "sys.h"
 
 static const char *svc_strings[] = {
@@ -1118,9 +1119,15 @@ CL_ParseServerMessage(void)
          case svc_setpause:
             cl.paused = MSG_ReadByte();
             if (cl.paused)
+            {
                CDAudio_Pause();
+               BGM_Pause();
+            }
             else
+            {
                CDAudio_Resume();
+               BGM_Resume();
+            }
             break;
 
          case svc_signonnum:
@@ -1160,9 +1167,9 @@ CL_ParseServerMessage(void)
             cl.looptrack = MSG_ReadByte();
             if ((cls.demoplayback || cls.demorecording)
                   && (cls.forcetrack != -1))
-               CDAudio_Play((byte)cls.forcetrack, true);
-            else
-               CDAudio_Play((byte)cl.cdtrack, true);
+               BGM_PlayCDtrack ((byte)cls.forcetrack, true);
+			else
+               BGM_PlayCDtrack ((byte)cl.cdtrack, true);
             break;
 
          case svc_intermission:

--- a/common/common.c
+++ b/common/common.c
@@ -1,5 +1,7 @@
 /*
 Copyright (C) 1996-1997 Id Software, Inc.
+Copyright (C) 2002-2009 John Fitzgibbons and others
+Copyright (C) 2010-2014 QuakeSpasm developers
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -25,6 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
+#include <errno.h>
 
 #ifdef NQ_HACK
 #include "quakedef.h"
@@ -861,7 +864,7 @@ COM_FileExtension
 ============
 */
 #ifdef NQ_HACK
-static const char *COM_FileExtension(const char *in)
+const char *COM_FileExtension(const char *in)
 {
    static char exten[8];
    const char *dot;
@@ -1394,7 +1397,7 @@ If the requested file is inside a packfile, a new FILE * will be opened
 into the file.
 ===========
 */
-int file_from_pak;	// global indicating file came from pack file
+int file_from_pak; // global indicating file came from pack file
 
 int COM_FOpenFile(const char *filename, FILE **file)
 {
@@ -1450,6 +1453,61 @@ int COM_FOpenFile(const char *filename, FILE **file)
    com_filesize = -1;
 
    return -1;
+}
+
+/*
+===========
+COM_FileExists
+
+Returns whether the file is found in the quake filesystem.
+===========
+*/
+qboolean COM_FileExists (const char *filename)
+{
+   searchpath_t *search;
+   char path[MAX_OSPATH];
+   pack_t *pak;
+   int i;
+   int findtime;
+
+   file_from_pak = 0;
+
+   // search through the path, one element at a time
+   for (search = com_searchpaths; search; search = search->next)
+   {
+      // is the element a pak file?
+      if (search->pack)
+      {
+         // look through all the pak file elements
+         pak = search->pack;
+         for (i = 0; i < pak->numfiles; i++)
+            if (!strcmp(pak->files[i].name, filename))
+            {	// found it!
+               com_filesize = pak->files[i].filelen;
+               file_from_pak = 1;
+               return true;
+            }
+      } else {
+         // check a file in the directory tree
+         if (!static_registered)
+         {
+            // if not a registered version, don't ever go beyond base
+            if (strchr(filename, '/') || strchr(filename, '\\'))
+               continue;
+         }
+         snprintf(path, sizeof(path), "%s/%s", search->filename, filename);
+         findtime = Sys_FileTime(path);
+         if (findtime == -1)
+            continue;
+
+         return true;
+      }
+   }
+
+   Sys_Printf("FindFile: can't find %s\n", filename);
+   com_filesize = -1;
+
+   return false;
 }
 
 static void COM_ScanDirDir(struct stree_root *root, struct RDIR *dir, const char *pfx,
@@ -2417,3 +2475,173 @@ int build_number(void)
    return b;
 }
 #endif /* QW_HACK */
+
+/* The following FS_*() stdio replacements are necessary if one is
+ * to perform non-sequential reads on files reopened on pak files
+ * because we need the bookkeeping about file start/end positions.
+ * Allocating and filling in the fshandle_t structure is the users'
+ * responsibility when the file is initially opened. */
+
+size_t FS_fread(void *ptr, size_t size, size_t nmemb, fshandle_t *fh)
+{
+	long byte_size;
+	long bytes_read;
+	size_t nmemb_read;
+
+	if (!fh) {
+		errno = EBADF;
+		return 0;
+	}
+	if (!ptr) {
+		errno = EFAULT;
+		return 0;
+	}
+	if (!size || !nmemb) {	/* no error, just zero bytes wanted */
+		errno = 0;
+		return 0;
+	}
+
+	byte_size = nmemb * size;
+	if (byte_size > fh->length - fh->pos)	/* just read to end */
+		byte_size = fh->length - fh->pos;
+	bytes_read = fread(ptr, 1, byte_size, fh->file);
+	fh->pos += bytes_read;
+
+	/* fread() must return the number of elements read,
+	 * not the total number of bytes. */
+	nmemb_read = bytes_read / size;
+	/* even if the last member is only read partially
+	 * it is counted as a whole in the return value. */
+	if (bytes_read % size)
+		nmemb_read++;
+
+	return nmemb_read;
+}
+
+int FS_fseek(fshandle_t *fh, long offset, int whence)
+{
+/* I don't care about 64 bit off_t or fseeko() here.
+ * the quake/hexen2 file system is 32 bits, anyway. */
+	int ret;
+
+	if (!fh) {
+		errno = EBADF;
+		return -1;
+	}
+
+	/* the relative file position shouldn't be smaller
+	 * than zero or bigger than the filesize. */
+	switch (whence)
+	{
+	case SEEK_SET:
+		break;
+	case SEEK_CUR:
+		offset += fh->pos;
+		break;
+	case SEEK_END:
+		offset = fh->length + offset;
+		break;
+	default:
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (offset < 0) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (offset > fh->length)	/* just seek to end */
+		offset = fh->length;
+
+	ret = fseek(fh->file, fh->start + offset, SEEK_SET);
+	if (ret < 0)
+		return ret;
+
+	fh->pos = offset;
+	return 0;
+}
+
+int FS_fclose(fshandle_t *fh)
+{
+	if (!fh) {
+		errno = EBADF;
+		return -1;
+	}
+	return fclose(fh->file);
+}
+
+long FS_ftell(fshandle_t *fh)
+{
+	if (!fh) {
+		errno = EBADF;
+		return -1;
+	}
+	return fh->pos;
+}
+
+void FS_rewind(fshandle_t *fh)
+{
+	if (!fh) return;
+	clearerr(fh->file);
+	fseek(fh->file, fh->start, SEEK_SET);
+	fh->pos = 0;
+}
+
+int FS_feof(fshandle_t *fh)
+{
+	if (!fh) {
+		errno = EBADF;
+		return -1;
+	}
+	if (fh->pos >= fh->length)
+		return -1;
+	return 0;
+}
+
+int FS_ferror(fshandle_t *fh)
+{
+	if (!fh) {
+		errno = EBADF;
+		return -1;
+	}
+	return ferror(fh->file);
+}
+
+int FS_fgetc(fshandle_t *fh)
+{
+	if (!fh) {
+		errno = EBADF;
+		return EOF;
+	}
+	if (fh->pos >= fh->length)
+		return EOF;
+	fh->pos += 1;
+	return fgetc(fh->file);
+}
+
+char *FS_fgets(char *s, int size, fshandle_t *fh)
+{
+	char *ret;
+
+	if (FS_feof(fh))
+		return NULL;
+
+	if (size > (fh->length - fh->pos) + 1)
+		size = (fh->length - fh->pos) + 1;
+
+	ret = fgets(s, size, fh->file);
+	fh->pos = ftell(fh->file) - fh->start;
+
+	return ret;
+}
+
+long FS_filelength (fshandle_t *fh)
+{
+	if (!fh) {
+		errno = EBADF;
+		return -1;
+	}
+	return fh->length;
+}
+

--- a/common/common.h
+++ b/common/common.h
@@ -181,6 +181,8 @@ void COM_Init(void);
 void COM_InitArgv(int argc, const char **argv);
 
 const char *COM_SkipPath(const char *pathname);
+const char *COM_FileExtension(const char *in);
+qboolean COM_FileExists(const char *filename);
 void COM_StripExtension(char *filename);
 void COM_FileBase(const char *in, char *out, size_t buflen);
 void COM_DefaultExtension(char *path, const char *extension);
@@ -197,6 +199,7 @@ struct cache_user_s;
 
 extern char com_basedir[MAX_OSPATH];
 extern char com_gamedir[MAX_OSPATH];
+extern int file_from_pak; // global indicating that file came from a pak
 
 void COM_WriteFile(const char *filename, const void *data, int len);
 int COM_FOpenFile(const char *filename, FILE **file);
@@ -242,5 +245,31 @@ extern char gamedirfile[];
 // Leilei Colored lighting
 
 extern byte	palmap2[64][64][64];	// 18-bit lookup table 
+
+/* The following FS_*() stdio replacements are necessary if one is
+ * to perform non-sequential reads on files reopened on pak files
+ * because we need the bookkeeping about file start/end positions.
+ * Allocating and filling in the fshandle_t structure is the users'
+ * responsibility when the file is initially opened. */
+
+typedef struct _fshandle_t
+{
+	FILE *file;
+	qboolean pak;	/* is the file read from a pak */
+	long start;	/* file or data start position */
+	long length;	/* file or data size */
+	long pos;	/* current position relative to start */
+} fshandle_t;
+
+size_t FS_fread(void *ptr, size_t size, size_t nmemb, fshandle_t *fh);
+int FS_fseek(fshandle_t *fh, long offset, int whence);
+long FS_ftell(fshandle_t *fh);
+void FS_rewind(fshandle_t *fh);
+int FS_feof(fshandle_t *fh);
+int FS_ferror(fshandle_t *fh);
+int FS_fclose(fshandle_t *fh);
+int FS_fgetc(fshandle_t *fh);
+char *FS_fgets(char *s, int size, fshandle_t *fh);
+long FS_filelength (fshandle_t *fh);
 
 #endif /* COMMON_H */

--- a/common/cvar.c
+++ b/common/cvar.c
@@ -306,6 +306,9 @@ void Cvar_RegisterVariable(cvar_t *variable)
    value[511] = '\0';
    variable->string = (const char*)Z_Malloc(1);
 
+   if (!(variable->flags & CVAR_CALLBACK))
+     variable->callback = NULL;
+
    /*
     * FIXME (BARF) - readonly cvars need to be initialised
     *                developer 1 allows set
@@ -315,6 +318,21 @@ void Cvar_RegisterVariable(cvar_t *variable)
    developer.value = 1;
    Cvar_Set(variable->name, value);
    developer.value = old_developer;
+}
+
+/*
+============
+Cvar_SetCallback
+
+Set a callback function to the var
+============
+*/
+void Cvar_SetCallback (cvar_t *var, cvar_callback func)
+{
+	var->callback = func;
+	if (func)
+		var->flags |= CVAR_CALLBACK;
+	else	var->flags &= ~CVAR_CALLBACK;
 }
 
 /*

--- a/common/cvar.h
+++ b/common/cvar.h
@@ -103,12 +103,15 @@ typedef struct cvar_s {
 
 #define CVAR_DEVELOPER (1U << 0) /* can't set during normal play */
 #define CVAR_OBSOLETE  (1U << 1) /* cvar has no effect; basically removed */
+#define CVAR_CALLBACK  (1U << 2)
 
 /*
  * register a cvar that already has the name, string, and optionally the
  * archive elements set.
  */
 void Cvar_RegisterVariable(cvar_t *variable);
+
+void Cvar_SetCallback(cvar_t *var, cvar_callback func);
 
 /* equivelant to "<name> <variable>" typed at the console */
 void Cvar_Set(const char *var_name, const char *value);

--- a/common/host.c
+++ b/common/host.c
@@ -35,6 +35,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "screen.h"
 #include "server.h"
 #include "sound.h"
+#include "bgmusic.h"
 #include "sys.h"
 #include "view.h"
 #include "wad.h"
@@ -816,6 +817,7 @@ Host_Init(quakeparms_t *parms)
 
 	S_Init();
 	CDAudio_Init();
+    BGM_Init();
 
 	Sbar_Init();
 	CL_Init();
@@ -865,6 +867,7 @@ Host_Shutdown(void)
 
     CDAudio_Shutdown();
     NET_Shutdown();
+    BGM_Shutdown();
     S_Shutdown();
     IN_Shutdown();
 

--- a/common/libretro.c
+++ b/common/libretro.c
@@ -45,7 +45,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "d_local.h"
 #include "sys.h"
 
+#include "qtypes.h"
 #include "sound.h"
+#include "bgmusic.h"
 #include "keys.h"
 #include "cdaudio_driver.h"
 
@@ -1138,6 +1140,8 @@ static unsigned audio_buffer_ptr;
 
 static void audio_process(void)
 {
+   /* adds music raw samples and/or advances midi driver */
+   BGM_Update(); 
    /* update audio */
    if (cls.state == ca_active)
    {
@@ -1168,13 +1172,14 @@ static void audio_callback(void)
    }
 }
 
-qboolean SNDDMA_Init(void)
+qboolean SNDDMA_Init(dma_t *dma)
 {
-   shm = &sn;
+   shm = dma;
    shm->speed = SAMPLERATE;
    shm->channels = 2;
    shm->samplepos = 0;
    shm->samplebits = 16;
+   shm->signed8 = 0;
    shm->samples = AUDIO_BUFFER_SAMPLES;
    shm->buffer = (unsigned char *volatile)audio_buffer;
 

--- a/common/menu.c
+++ b/common/menu.c
@@ -969,12 +969,12 @@ M_AdjustSliders(int dir)
 	Cvar_SetValue("bgmvolume", bgmvolume.value);
 	break;
     case 7:			// sfx volume
-	volume.value += dir * 0.1;
-	if (volume.value < 0)
-	    volume.value = 0;
-	if (volume.value > 1)
-	    volume.value = 1;
-	Cvar_SetValue("volume", volume.value);
+	sfxvolume.value += dir * 0.1;
+	if (sfxvolume.value < 0)
+	    sfxvolume.value = 0;
+	if (sfxvolume.value > 1)
+	    sfxvolume.value = 1;
+	Cvar_SetValue("volume", sfxvolume.value);
 	break;
 
     case 8:			// allways run
@@ -1092,7 +1092,7 @@ M_Options_Draw(void)
     M_DrawSlider(220, 80, r);
 
     M_Print(16, 88, "          Sound Volume");
-    r = volume.value;
+    r = sfxvolume.value;
     M_DrawSlider(220, 88, r);
 
     M_Print(16, 96, "            Always Run");

--- a/common/snd_codec.c
+++ b/common/snd_codec.c
@@ -1,0 +1,323 @@
+/*
+ * Audio Codecs: Adapted from ioquake3 with changes.
+ * For now, only handles streaming music, not sound effects.
+ *
+ * Copyright (C) 1999-2005 Id Software, Inc.
+ * Copyright (C) 2005 Stuart Dalton <badcdev@gmail.com>
+ * Copyright (C) 2010-2012 O.Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <bsd/string.h>
+#include "quakedef.h"
+#include "sound.h"
+#include "common.h"
+#include "console.h"
+#include "snd_codec.h"
+#include "snd_codeci.h"
+
+/* headers for individual codecs */
+#include "snd_mikmod.h"
+#include "snd_modplug.h"
+#include "snd_umx.h"
+#include "snd_wave.h"
+#include "snd_flac.h"
+#include "snd_mp3.h"
+#include "snd_vorbis.h"
+#include "snd_opus.h"
+
+
+static snd_codec_t *codecs;
+
+/*
+=================
+S_CodecRegister
+=================
+*/
+static void S_CodecRegister(snd_codec_t *codec)
+{
+	codec->next = codecs;
+	codecs = codec;
+}
+
+/*
+=================
+S_CodecInit
+=================
+*/
+void S_CodecInit (void)
+{
+	snd_codec_t *codec;
+	codecs = NULL;
+
+	/* Register in the inverse order
+	 * of codec choice preference: */
+#ifdef USE_CODEC_UMX
+	S_CodecRegister(&umx_codec);
+#endif
+#ifdef USE_CODEC_MODPLUG
+	S_CodecRegister(&modplug_codec);
+#endif
+#ifdef USE_CODEC_MIKMOD
+	S_CodecRegister(&mikmod_codec);
+#endif
+#ifdef USE_CODEC_WAVE
+	S_CodecRegister(&wav_codec);
+#endif
+#ifdef USE_CODEC_FLAC
+	S_CodecRegister(&flac_codec);
+#endif
+#ifdef USE_CODEC_MP3
+	S_CodecRegister(&mp3_codec);
+#endif
+#ifdef USE_CODEC_VORBIS
+	S_CodecRegister(&vorbis_codec);
+#endif
+#ifdef USE_CODEC_OPUS
+	S_CodecRegister(&opus_codec);
+#endif
+
+	codec = codecs;
+	while (codec)
+	{
+		codec->initialize();
+		codec = codec->next;
+	}
+}
+
+/*
+=================
+S_CodecShutdown
+=================
+*/
+void S_CodecShutdown (void)
+{
+	snd_codec_t *codec = codecs;
+	while (codec)
+	{
+		codec->shutdown();
+		codec = codec->next;
+	}
+	codecs = NULL;
+}
+
+/*
+=================
+S_CodecOpenStream
+=================
+*/
+snd_stream_t *S_CodecOpenStreamType (const char *filename, unsigned int type)
+{
+	snd_codec_t *codec;
+	snd_stream_t *stream;
+
+	if (type == CODECTYPE_NONE)
+	{
+		Con_Printf("Bad type for %s\n", filename);
+		return NULL;
+	}
+
+	codec = codecs;
+	while (codec)
+	{
+		if (type == codec->type)
+			break;
+		codec = codec->next;
+	}
+	if (!codec)
+	{
+		Con_Printf("Unknown type for %s\n", filename);
+		return NULL;
+	}
+	stream = S_CodecUtilOpen(filename, codec);
+	if (stream) {
+		if (codec->codec_open(stream))
+			stream->status = STREAM_PLAY;
+		else	S_CodecUtilClose(&stream);
+	}
+	return stream;
+}
+
+snd_stream_t *S_CodecOpenStreamExt (const char *filename)
+{
+	snd_codec_t *codec;
+	snd_stream_t *stream;
+	const char *ext;
+
+	ext = COM_FileExtension(filename);
+	if (! *ext)
+	{
+		Con_Printf("No extension for %s\n", filename);
+		return NULL;
+	}
+
+	codec = codecs;
+	while (codec)
+	{
+		if (!strcasecmp(ext, codec->ext))
+			break;
+		codec = codec->next;
+	}
+	if (!codec)
+	{
+		Con_Printf("Unknown extension for %s\n", filename);
+		return NULL;
+	}
+	stream = S_CodecUtilOpen(filename, codec);
+	if (stream) {
+		if (codec->codec_open(stream))
+			stream->status = STREAM_PLAY;
+		else	S_CodecUtilClose(&stream);
+	}
+	return stream;
+}
+
+snd_stream_t *S_CodecOpenStreamAny (const char *filename)
+{
+	snd_codec_t *codec;
+	snd_stream_t *stream;
+	const char *ext;
+
+	ext = COM_FileExtension(filename);
+	if (! *ext)	/* try all available */
+	{
+		char tmp[MAX_QPATH];
+
+		codec = codecs;
+		while (codec)
+		{
+			snprintf(tmp, sizeof(tmp), "%s.%s", filename, codec->ext);
+			stream = S_CodecUtilOpen(tmp, codec);
+			if (stream) {
+				if (codec->codec_open(stream)) {
+					stream->status = STREAM_PLAY;
+					return stream;
+				}
+				S_CodecUtilClose(&stream);
+			}
+			codec = codec->next;
+		}
+
+		return NULL;
+	}
+	else	/* use the name as is */
+	{
+		codec = codecs;
+		while (codec)
+		{
+			if (!strcasecmp(ext, codec->ext))
+				break;
+			codec = codec->next;
+		}
+		if (!codec)
+		{
+			Con_Printf("Unknown extension for %s\n", filename);
+			return NULL;
+		}
+		stream = S_CodecUtilOpen(filename, codec);
+		if (stream) {
+			if (codec->codec_open(stream))
+				stream->status = STREAM_PLAY;
+			else	S_CodecUtilClose(&stream);
+		}
+		return stream;
+	}
+}
+
+qboolean S_CodecForwardStream (snd_stream_t *stream, unsigned int type)
+{
+	snd_codec_t *codec = codecs;
+
+	while (codec)
+	{
+		if (type == codec->type)
+			break;
+		codec = codec->next;
+	}
+	if (!codec) return false;
+	stream->codec = codec;
+	return codec->codec_open(stream);
+}
+
+void S_CodecCloseStream (snd_stream_t *stream)
+{
+	stream->status = STREAM_NONE;
+	stream->codec->codec_close(stream);
+}
+
+int S_CodecRewindStream (snd_stream_t *stream)
+{
+	return stream->codec->codec_rewind(stream);
+}
+
+int S_CodecReadStream (snd_stream_t *stream, int bytes, void *buffer)
+{
+	return stream->codec->codec_read(stream, bytes, buffer);
+}
+
+/* Util functions (used by codecs) */
+
+snd_stream_t *S_CodecUtilOpen(const char *filename, snd_codec_t *codec)
+{
+	snd_stream_t *stream;
+	FILE *handle;
+	qboolean pak;
+	long length;
+
+	/* Try to open the file */
+	length = (long) COM_FOpenFile(filename, &handle);
+	pak = file_from_pak;
+	if (length == -1)
+	{
+		Con_DPrintf("Couldn't open %s\n", filename);
+		return NULL;
+	}
+
+	/* Allocate a stream, Z_Malloc zeroes its content */
+	stream = (snd_stream_t *) Z_Malloc(sizeof(snd_stream_t));
+	stream->codec = codec;
+	stream->fh.file = handle;
+	stream->fh.start = ftell(handle);
+	stream->fh.pos = 0;
+	stream->fh.length = length;
+	stream->fh.pak = stream->pak = pak;
+	strlcpy(stream->name, filename, MAX_QPATH);
+
+	return stream;
+}
+
+void S_CodecUtilClose(snd_stream_t **stream)
+{
+	fclose((*stream)->fh.file);
+	Z_Free(*stream);
+	*stream = NULL;
+}
+
+int S_CodecIsAvailable (unsigned int type)
+{
+	snd_codec_t *codec = codecs;
+	while (codec)
+	{
+		if (type == codec->type) {
+			return codec->initialized;
+        }
+		codec = codec->next;
+	}
+	return -1;
+}
+

--- a/common/snd_codec.h
+++ b/common/snd_codec.h
@@ -1,0 +1,106 @@
+/*
+ * Audio Codecs: Adapted from ioquake3 with changes.
+ * For now, only handles streaming music, not sound effects.
+ *
+ * Copyright (C) 1999-2005 Id Software, Inc.
+ * Copyright (C) 2005 Stuart Dalton <badcdev@gmail.com>
+ * Copyright (C) 2010-2012 O.Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef _SND_CODEC_H_
+#define _SND_CODEC_H_
+
+#include "common.h"
+
+typedef struct snd_info_s
+{
+	int rate;
+	int bits, width;
+	int channels;
+	int samples;
+	int blocksize;
+	int size;
+	int dataofs;
+} snd_info_t;
+
+typedef enum {
+	STREAM_NONE = -1,
+	STREAM_INIT,
+	STREAM_PAUSE,
+	STREAM_PLAY
+} stream_status_t;
+
+typedef struct snd_codec_s snd_codec_t;
+
+typedef struct snd_stream_s
+{
+	fshandle_t fh;
+	qboolean pak;
+	char name[MAX_QPATH];	/* name of the source file */
+	snd_info_t info;
+	stream_status_t status;
+	snd_codec_t *codec;	/* codec handling this stream */
+	void *priv;		/* data private to the codec. */
+} snd_stream_t;
+
+
+void S_CodecInit (void);
+void S_CodecShutdown (void);
+
+/* Callers of the following S_CodecOpenStream* functions
+ * are reponsible for attaching any path to the filename */
+
+snd_stream_t *S_CodecOpenStreamType (const char *filename, unsigned int type);
+	/* Decides according to the required type. */
+
+snd_stream_t *S_CodecOpenStreamAny (const char *filename);
+	/* Decides according to file extension. if the
+	 * name has no extension, try all available. */
+
+snd_stream_t *S_CodecOpenStreamExt (const char *filename);
+	/* Decides according to file extension. the name
+	 * MUST have an extension. */
+
+void S_CodecCloseStream (snd_stream_t *stream);
+int S_CodecReadStream (snd_stream_t *stream, int bytes, void *buffer);
+int S_CodecRewindStream (snd_stream_t *stream);
+
+snd_stream_t *S_CodecUtilOpen(const char *filename, snd_codec_t *codec);
+void S_CodecUtilClose(snd_stream_t **stream);
+
+
+#define CODECTYPE_NONE		0
+#define CODECTYPE_MID		(1U << 0)
+#define CODECTYPE_MOD		(1U << 1)
+#define CODECTYPE_FLAC		(1U << 2)
+#define CODECTYPE_WAV		(1U << 3)
+#define CODECTYPE_MP3		(1U << 4)
+#define CODECTYPE_VORBIS	(1U << 5)
+#define CODECTYPE_OPUS		(1U << 6)
+#define CODECTYPE_UMX		(1U << 7)
+
+#define CODECTYPE_WAVE		CODECTYPE_WAV
+#define CODECTYPE_MIDI		CODECTYPE_MID
+
+int S_CodecIsAvailable (unsigned int type);
+	/* return 1 if available, 0 if codec failed init
+	 * or -1 if no such codec is present. */
+
+#endif	/* _SND_CODEC_H_ */
+

--- a/common/snd_codeci.h
+++ b/common/snd_codeci.h
@@ -1,0 +1,55 @@
+/*
+ * Audio Codecs: Adapted from ioquake3 with changes.
+ * For now, only handles streaming music, not sound effects.
+ *
+ * Copyright (C) 1999-2005 Id Software, Inc.
+ * Copyright (C) 2005 Stuart Dalton <badcdev@gmail.com>
+ * Copyright (C) 2010-2012 O.Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef _SND_CODECI_H_
+#define _SND_CODECI_H_
+
+/* Codec internals */
+typedef qboolean (*CODEC_INIT)(void);
+typedef void (*CODEC_SHUTDOWN)(void);
+typedef qboolean (*CODEC_OPEN)(snd_stream_t *stream);
+typedef int (*CODEC_READ)(snd_stream_t *stream, int bytes, void *buffer);
+typedef int (*CODEC_REWIND)(snd_stream_t *stream);
+typedef void (*CODEC_CLOSE)(snd_stream_t *stream);
+
+struct snd_codec_s
+{
+	unsigned int type;	/* handled data type. (1U << n) */
+	qboolean initialized;	/* init succeedded */
+	const char *ext;	/* expected extension */
+	CODEC_INIT initialize;
+	CODEC_SHUTDOWN shutdown;
+	CODEC_OPEN codec_open;
+	CODEC_READ codec_read;
+	CODEC_REWIND codec_rewind;
+	CODEC_CLOSE codec_close;
+	snd_codec_t *next;
+};
+
+qboolean S_CodecForwardStream (snd_stream_t *stream, unsigned int type);
+			/* Forward a stream to another codec of 'type' type. */
+
+#endif	/* _SND_CODECI_H_ */
+

--- a/common/snd_dma.c
+++ b/common/snd_dma.c
@@ -85,7 +85,6 @@ cvar_t sfxvolume = { "volume", "0.7", true };
 
 static cvar_t nosound = { "nosound", "0" };
 static cvar_t precache = { "precache", "1" };
-static cvar_t bgmbuffer = { "bgmbuffer", "4096" };
 static cvar_t ambient_level = { "ambient_level", "0.3" };
 static cvar_t ambient_fade = { "ambient_fade", "100" };
 static cvar_t snd_noextraupdate = { "snd_noextraupdate", "0" };
@@ -115,6 +114,11 @@ static void S_SoundInfo_f(void)
    Con_Printf("%5d speed\n", shm->speed);
    Con_Printf("%p dma buffer\n", shm->buffer);
    Con_Printf("%5d total_channels\n", total_channels);
+}
+
+static void SND_Callback_sfxvolume (cvar_t *var)
+{
+	SND_InitScaletable ();
 }
 
 /*
@@ -167,7 +171,7 @@ S_Init(void)
     Cvar_RegisterVariable(&nosound);
     Cvar_RegisterVariable(&sfxvolume);
     Cvar_RegisterVariable(&precache);
-    Cvar_RegisterVariable(&bgmbuffer);
+    Cvar_RegisterVariable(&bgmvolume);
     Cvar_RegisterVariable(&ambient_level);
     Cvar_RegisterVariable(&ambient_fade);
     Cvar_RegisterVariable(&snd_noextraupdate);
@@ -176,6 +180,8 @@ S_Init(void)
     snd_initialized = true;
 
     S_Startup();
+
+	Cvar_SetCallback(&sfxvolume, SND_Callback_sfxvolume);
 
     SND_InitScaletable();
 

--- a/common/snd_dma.c
+++ b/common/snd_dma.c
@@ -58,7 +58,7 @@ static qboolean snd_initialized = false;
 
 /* pointer should go away (JC?) */
 volatile dma_t *shm = 0;
-volatile dma_t sn;
+static dma_t sn;
 
 static vec3_t listener_origin;
 static vec3_t listener_forward;
@@ -72,6 +72,9 @@ int paintedtime;		/* sample PAIRS */
 #define	MAX_SFX 512
 static sfx_t *known_sfx;	/* hunk allocated [MAX_SFX] */
 static int num_sfx;
+
+int s_rawend;
+portable_samplepair_t	s_rawsamples[MAX_RAW_SAMPLES];
 
 static sfx_t *ambient_sfx[NUM_AMBIENTS];
 

--- a/common/snd_dma.c
+++ b/common/snd_dma.c
@@ -77,7 +77,8 @@ static sfx_t *ambient_sfx[NUM_AMBIENTS];
 
 static int sound_started = 0;
 
-cvar_t volume = { "volume", "0.7", true };
+cvar_t bgmvolume = { "bgmvolume", "1", true };
+cvar_t sfxvolume = { "volume", "0.7", true };
 
 static cvar_t nosound = { "nosound", "0" };
 static cvar_t precache = { "precache", "1" };
@@ -127,7 +128,7 @@ S_Startup(void)
 
    if (!fakedma)
    {
-      int rc = SNDDMA_Init();
+      int rc = SNDDMA_Init(&sn);
       if (!rc)
       {
          Con_Printf("%s: SNDDMA_Init failed.\n", __func__);
@@ -161,7 +162,7 @@ S_Init(void)
     Cmd_AddCommand("soundinfo", S_SoundInfo_f);
 
     Cvar_RegisterVariable(&nosound);
-    Cvar_RegisterVariable(&volume);
+    Cvar_RegisterVariable(&sfxvolume);
     Cvar_RegisterVariable(&precache);
     Cvar_RegisterVariable(&bgmbuffer);
     Cvar_RegisterVariable(&ambient_level);

--- a/common/snd_flac.c
+++ b/common/snd_flac.c
@@ -1,0 +1,390 @@
+/*
+ * fLaC streaming music support, loosely based QuakeForge implementation
+ * with modifications.  requires libFLAC >= 1.0.4 at compile and runtime.
+ *
+ * Copyright (C) 2005 Bill Currie <bill@taniwha.org>
+ * Copyright (C) 2013 O.Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "quakedef.h"
+#include "sound.h"
+#include "console.h"
+
+#if defined(USE_CODEC_FLAC)
+#include "snd_codec.h"
+#include "snd_codeci.h"
+#include "snd_flac.h"
+
+#undef LEGACY_FLAC
+#include <FLAC/stream_decoder.h>
+/* FLAC 1.1.3 has FLAC_API_VERSION_CURRENT == 8 */
+#if !defined(FLAC_API_VERSION_CURRENT) || ((FLAC_API_VERSION_CURRENT+0) < 8)
+#define LEGACY_FLAC
+#include <FLAC/seekable_stream_decoder.h>
+#endif
+#include <FLAC/metadata.h>
+
+#ifdef LEGACY_FLAC
+#define FLAC__StreamDecoder					FLAC__SeekableStreamDecoder
+#define FLAC__StreamDecoderReadStatus				FLAC__SeekableStreamDecoderReadStatus
+#define FLAC__StreamDecoderSeekStatus				FLAC__SeekableStreamDecoderSeekStatus
+#define FLAC__StreamDecoderTellStatus				FLAC__SeekableStreamDecoderTellStatus
+#define FLAC__StreamDecoderLengthStatus				FLAC__SeekableStreamDecoderLengthStatus
+
+#define FLAC__stream_decoder_new				FLAC__seekable_stream_decoder_new
+#define FLAC__stream_decoder_finish				FLAC__seekable_stream_decoder_finish
+#define FLAC__stream_decoder_delete				FLAC__seekable_stream_decoder_delete
+#define FLAC__stream_decoder_process_single			FLAC__seekable_stream_decoder_process_single
+#define FLAC__stream_decoder_seek_absolute			FLAC__seekable_stream_decoder_seek_absolute
+#define FLAC__stream_decoder_process_until_end_of_metadata	FLAC__seekable_stream_decoder_process_until_end_of_metadata
+#define FLAC__stream_decoder_get_state				FLAC__seekable_stream_decoder_get_state
+
+#define FLAC__STREAM_DECODER_INIT_STATUS_OK			FLAC__SEEKABLE_STREAM_DECODER_OK
+#define FLAC__STREAM_DECODER_READ_STATUS_CONTINUE		FLAC__SEEKABLE_STREAM_DECODER_READ_STATUS_OK
+#define FLAC__STREAM_DECODER_READ_STATUS_ABORT			FLAC__SEEKABLE_STREAM_DECODER_READ_STATUS_ERROR
+#define FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM		FLAC__SEEKABLE_STREAM_DECODER_READ_STATUS_OK	/* !!! */
+#define FLAC__STREAM_DECODER_WRITE_STATUS_ABORT			FLAC__STREAM_DECODER_WRITE_STATUS_ABORT
+#define FLAC__STREAM_DECODER_SEEK_STATUS_OK			FLAC__SEEKABLE_STREAM_DECODER_SEEK_STATUS_OK
+#define FLAC__STREAM_DECODER_SEEK_STATUS_ERROR			FLAC__SEEKABLE_STREAM_DECODER_SEEK_STATUS_ERROR
+#define FLAC__STREAM_DECODER_TELL_STATUS_OK			FLAC__SEEKABLE_STREAM_DECODER_TELL_STATUS_OK
+#define FLAC__STREAM_DECODER_TELL_STATUS_ERROR			FLAC__SEEKABLE_STREAM_DECODER_TELL_STATUS_ERROR
+#define FLAC__STREAM_DECODER_LENGTH_STATUS_OK			FLAC__SEEKABLE_STREAM_DECODER_LENGTH_STATUS_OK
+#endif
+
+typedef struct {
+	FLAC__StreamDecoder *decoder;
+	fshandle_t *file;
+	snd_info_t *info;
+	byte *buffer;
+	int size, pos, error;
+} flacfile_t;
+
+/* CALLBACK FUNCTIONS: */
+static void
+flac_error_func (const FLAC__StreamDecoder *decoder,
+		 FLAC__StreamDecoderErrorStatus status, void *client_data)
+{
+	flacfile_t *ff = (flacfile_t *) client_data;
+	ff->error = -1;
+	Con_Printf ("FLAC: decoder error %i\n", status);
+}
+
+static FLAC__StreamDecoderReadStatus
+flac_read_func (const FLAC__StreamDecoder *decoder, FLAC__byte buffer[],
+		size_t *bytes, void *client_data)
+{
+	flacfile_t *ff = (flacfile_t *) client_data;
+	if (*bytes > 0)
+	{
+		*bytes = FS_fread(buffer, 1, *bytes, ff->file);
+		if (FS_ferror(ff->file))
+			return FLAC__STREAM_DECODER_READ_STATUS_ABORT;
+		if (*bytes == 0)
+			return FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM;
+		return FLAC__STREAM_DECODER_READ_STATUS_CONTINUE;
+	}
+	return FLAC__STREAM_DECODER_READ_STATUS_ABORT;
+}
+
+static FLAC__StreamDecoderSeekStatus
+flac_seek_func (const FLAC__StreamDecoder *decoder,
+		FLAC__uint64 absolute_byte_offset, void *client_data)
+{
+	flacfile_t *ff = (flacfile_t *) client_data;
+	if (FS_fseek(ff->file, (long)absolute_byte_offset, SEEK_SET) < 0)
+		return FLAC__STREAM_DECODER_SEEK_STATUS_ERROR;
+	return FLAC__STREAM_DECODER_SEEK_STATUS_OK;
+}
+
+static FLAC__StreamDecoderTellStatus
+flac_tell_func (const FLAC__StreamDecoder *decoder,
+		FLAC__uint64 *absolute_byte_offset, void *client_data)
+{
+	flacfile_t *ff = (flacfile_t *) client_data;
+	long pos = FS_ftell (ff->file);
+	if (pos < 0) return FLAC__STREAM_DECODER_TELL_STATUS_ERROR;
+	*absolute_byte_offset = (FLAC__uint64) pos;
+	return FLAC__STREAM_DECODER_TELL_STATUS_OK;
+}
+
+static FLAC__StreamDecoderLengthStatus
+flac_length_func (const FLAC__StreamDecoder *decoder,
+		  FLAC__uint64 *stream_length, void *client_data)
+{
+	flacfile_t *ff = (flacfile_t *) client_data;
+	*stream_length = (FLAC__uint64) FS_filelength (ff->file);
+	return FLAC__STREAM_DECODER_LENGTH_STATUS_OK;
+}
+
+static FLAC__bool
+flac_eof_func (const FLAC__StreamDecoder *decoder, void *client_data)
+{
+	flacfile_t *ff = (flacfile_t *) client_data;
+	if (FS_feof (ff->file)) return true;
+	return false;
+}
+
+static FLAC__StreamDecoderWriteStatus
+flac_write_func (const FLAC__StreamDecoder *decoder,
+		 const FLAC__Frame *frame, const FLAC__int32 * const buffer[],
+		 void *client_data)
+{
+	flacfile_t *ff = (flacfile_t *) client_data;
+
+	if (!ff->buffer) {
+		ff->buffer = (byte *) malloc (ff->info->blocksize * ff->info->channels * ff->info->width);
+		if (!ff->buffer) {
+			ff->error = -1; /* needn't set this here, but... */
+			Con_Printf("Insufficient memory for fLaC audio\n");
+			return FLAC__STREAM_DECODER_WRITE_STATUS_ABORT;
+		}
+	}
+
+	if (ff->info->channels == 1)
+	{
+		unsigned i;
+		const FLAC__int32 *in = buffer[0];
+
+		if (ff->info->bits == 8)
+		{
+			byte  *out = ff->buffer;
+			for (i = 0; i < frame->header.blocksize; i++)
+				*out++ = *in++ + 128;
+		}
+		else
+		{
+			short *out = (short *) ff->buffer;
+			for (i = 0; i < frame->header.blocksize; i++)
+				*out++ = *in++;
+		}
+	}
+	else
+	{
+		unsigned i;
+		const FLAC__int32 *li = buffer[0];
+		const FLAC__int32 *ri = buffer[1];
+
+		if (ff->info->bits == 8)
+		{
+			char  *lo = (char *) ff->buffer + 0;
+			char  *ro = (char *) ff->buffer + 1;
+			for (i = 0; i < frame->header.blocksize; i++, lo++, ro++)
+			{
+				*lo++ = *li++ + 128;
+				*ro++ = *ri++ + 128;
+			}
+		}
+		else
+		{
+			short *lo = (short *) ff->buffer + 0;
+			short *ro = (short *) ff->buffer + 1;
+			for (i = 0; i < frame->header.blocksize; i++, lo++, ro++)
+			{
+				*lo++ = *li++;
+				*ro++ = *ri++;
+			}
+		}
+	}
+
+	ff->size = frame->header.blocksize * ff->info->width * ff->info->channels;
+	ff->pos = 0;
+	return FLAC__STREAM_DECODER_WRITE_STATUS_CONTINUE;
+}
+
+static void
+flac_meta_func (const FLAC__StreamDecoder *decoder,
+			    const FLAC__StreamMetadata *metadata, void *client_data)
+{
+	flacfile_t *ff = (flacfile_t *) client_data;
+	if (metadata->type == FLAC__METADATA_TYPE_STREAMINFO)
+	{
+		ff->info->rate = metadata->data.stream_info.sample_rate;
+		ff->info->bits = metadata->data.stream_info.bits_per_sample;
+		ff->info->width = ff->info->bits / 8;
+		ff->info->channels = metadata->data.stream_info.channels;
+		ff->info->blocksize = metadata->data.stream_info.max_blocksize;
+		ff->info->dataofs = 0;	/* got the STREAMINFO metadata */
+	}
+}
+
+
+static qboolean S_FLAC_CodecInitialize (void)
+{
+	return true;
+}
+
+static void S_FLAC_CodecShutdown (void)
+{
+}
+
+static qboolean S_FLAC_CodecOpenStream (snd_stream_t *stream)
+{
+	flacfile_t *ff;
+	int rc;
+
+	ff = (flacfile_t *) Z_Malloc(sizeof(flacfile_t));
+
+	ff->decoder = FLAC__stream_decoder_new ();
+	if (ff->decoder == NULL)
+	{
+		Con_Printf("Unable to create fLaC decoder\n");
+		goto _fail;
+	}
+
+	stream->priv = ff;
+	ff->info = & stream->info;
+	ff->file = & stream->fh;
+	ff->info->dataofs = -1; /* check for STREAMINFO metadata existence */
+
+#ifdef LEGACY_FLAC
+	FLAC__seekable_stream_decoder_set_error_callback (ff->decoder, flac_error_func);
+	FLAC__seekable_stream_decoder_set_read_callback (ff->decoder, flac_read_func);
+	FLAC__seekable_stream_decoder_set_seek_callback (ff->decoder, flac_seek_func);
+	FLAC__seekable_stream_decoder_set_tell_callback (ff->decoder, flac_tell_func);
+	FLAC__seekable_stream_decoder_set_length_callback (ff->decoder, flac_length_func);
+	FLAC__seekable_stream_decoder_set_eof_callback (ff->decoder, flac_eof_func);
+	FLAC__seekable_stream_decoder_set_write_callback (ff->decoder, flac_write_func);
+	FLAC__seekable_stream_decoder_set_metadata_callback (ff->decoder, flac_meta_func);
+	FLAC__seekable_stream_decoder_set_client_data (ff->decoder, ff);
+	rc = FLAC__seekable_stream_decoder_init (ff->decoder);
+#else
+	rc = FLAC__stream_decoder_init_stream(ff->decoder,
+								flac_read_func,
+								flac_seek_func,
+								flac_tell_func,
+								flac_length_func,
+								flac_eof_func,
+								flac_write_func,
+								flac_meta_func,
+								flac_error_func,
+							ff);
+#endif
+	if (rc != FLAC__STREAM_DECODER_INIT_STATUS_OK) /* unlikely */
+	{
+		Con_Printf ("FLAC: decoder init error %i\n", rc);
+		goto _fail;
+	}
+
+	rc = FLAC__stream_decoder_process_until_end_of_metadata (ff->decoder);
+	if (rc == false || ff->error)
+	{
+		rc = FLAC__stream_decoder_get_state(ff->decoder);
+		Con_Printf("%s not a valid flac file? (decoder state %i)\n",
+						stream->name, rc);
+		goto _fail;
+	}
+
+	if (ff->info->dataofs < 0)
+	{
+		Con_Printf("%s has no STREAMINFO\n", stream->name);
+		goto _fail;
+	}
+	if (ff->info->bits != 8 && ff->info->bits != 16)
+	{
+		Con_Printf("%s is not 8 or 16 bit\n", stream->name);
+		goto _fail;
+	}
+	if (ff->info->channels != 1 && ff->info->channels != 2)
+	{
+		Con_Printf("Unsupported number of channels %d in %s\n",
+					ff->info->channels, stream->name);
+		goto _fail;
+	}
+
+	return true;
+
+_fail:
+	if (ff->decoder)
+	{
+		FLAC__stream_decoder_finish (ff->decoder);
+		FLAC__stream_decoder_delete (ff->decoder);
+	}
+	Z_Free(ff);
+	return false;
+}
+
+static int S_FLAC_CodecReadStream (snd_stream_t *stream, int len, void *buffer)
+{
+	flacfile_t *ff = (flacfile_t *) stream->priv;
+	byte *buf = (byte *) buffer;
+	int count = 0;
+
+	while (len) {
+		int res = 0;
+		if (ff->size == ff->pos)
+			FLAC__stream_decoder_process_single (ff->decoder);
+		if (ff->error) return -1;
+		res = ff->size - ff->pos;
+		if (res > len)
+			res = len;
+		if (res > 0) {
+			memcpy (buf, ff->buffer + ff->pos, res);
+			count += res;
+			len -= res;
+			buf += res;
+			ff->pos += res;
+		} else if (res < 0) { /* error */
+			return -1;
+		} else {
+			Con_DPrintf ("FLAC: EOF\n");
+			break;
+		}
+	}
+	return count;
+}
+
+static void S_FLAC_CodecCloseStream (snd_stream_t *stream)
+{
+	flacfile_t *ff = (flacfile_t *) stream->priv;
+
+	FLAC__stream_decoder_finish (ff->decoder);
+	FLAC__stream_decoder_delete (ff->decoder);
+
+	if (ff->buffer)
+			free(ff->buffer);
+	Z_Free(ff);
+
+	S_CodecUtilClose(&stream);
+}
+
+static int S_FLAC_CodecRewindStream (snd_stream_t *stream)
+{
+	flacfile_t *ff = (flacfile_t *) stream->priv;
+
+	ff->pos = ff->size = 0;
+	if (FLAC__stream_decoder_seek_absolute(ff->decoder, 0)) return 0;
+	return -1;
+}
+
+snd_codec_t flac_codec =
+{
+	CODECTYPE_FLAC,
+	true,	/* always available. */
+	"flac",
+	S_FLAC_CodecInitialize,
+	S_FLAC_CodecShutdown,
+	S_FLAC_CodecOpenStream,
+	S_FLAC_CodecReadStream,
+	S_FLAC_CodecRewindStream,
+	S_FLAC_CodecCloseStream,
+	NULL
+};
+
+#endif	/* USE_CODEC_FLAC */
+

--- a/common/snd_flac.h
+++ b/common/snd_flac.h
@@ -1,0 +1,13 @@
+/* fLaC streaming music support. */
+
+#if !defined(_SND_FLAC_H_)
+#define _SND_FLAC_H_ 1
+
+#if defined(USE_CODEC_FLAC)
+
+extern snd_codec_t flac_codec;
+
+#endif	/* USE_CODEC_FLAC */
+
+#endif	/* ! _SND_FLAC_H_ */
+

--- a/common/snd_mem.c
+++ b/common/snd_mem.c
@@ -25,17 +25,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "sound.h"
 #include "sys.h"
 
-typedef struct {
-    int rate;
-    int width;
-    int channels;
-    int loopstart;
-    int samples;
-    int dataofs;		// chunk starts this many bytes from file start
-} wavinfo_t;
-
-static wavinfo_t *GetWavinfo(const char *name, const byte *wav, int wavlength);
-
 /*
 ================
 ResampleSfx
@@ -253,7 +242,8 @@ FindChunk(const char *name, const char *filename)
 GetWavinfo
 ============
 */
-static wavinfo_t *GetWavinfo(const char *name, const byte *wav, int wavlength)
+
+wavinfo_t *GetWavinfo (const char *name, byte *wav, int wavlength)
 {
    static wavinfo_t info;
    int format;

--- a/common/snd_mikmod.c
+++ b/common/snd_mikmod.c
@@ -1,0 +1,206 @@
+/*
+ * tracker music (module file) decoding support using libmikmod
+ * Copyright (C) 2013 O.Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "quakedef.h"
+#include "sound.h"
+
+#if defined(USE_CODEC_MIKMOD)
+#include "snd_codec.h"
+#include "snd_codeci.h"
+#include "snd_mikmod.h"
+#include <mikmod.h>
+
+#if ((LIBMIKMOD_VERSION+0) < 0x030105)
+#error libmikmod version is way too old and unusable.
+#endif
+#if (LIBMIKMOD_VERSION < 0x030107) /* ancient libmikmod */
+#define S_MIKMOD_initlib(c) MikMod_Init()
+#else
+#define S_MIKMOD_initlib(c) MikMod_Init(c)
+#endif
+
+#ifndef DMODE_NOISEREDUCTION
+#define DMODE_NOISEREDUCTION 0x1000 /* Low pass filtering */
+#endif
+#ifndef DMODE_SIMDMIXER
+#define DMODE_SIMDMIXER 0x0800 /* enable SIMD mixing */
+#endif
+
+typedef struct _mik_priv {
+/* struct MREADER in libmikmod <= 3.2.0-beta2
+ * doesn't have iobase members. adding them here
+ * so that if we compile against 3.2.0-beta2, we
+ * can still run OK against 3.2.0b3 and newer. */
+	struct MREADER reader;
+	long iobase, prev_iobase;
+	fshandle_t *fh;
+	MODULE *module;
+} mik_priv_t;
+
+static int MIK_Seek (MREADER *r, long ofs, int whence)
+{
+	return FS_fseek(((mik_priv_t *)r)->fh, ofs, whence);
+}
+
+static long MIK_Tell (MREADER *r)
+{
+	return FS_ftell(((mik_priv_t *)r)->fh);
+}
+
+static BOOL MIK_Read (MREADER *r, void *ptr, size_t siz)
+{
+	return !!FS_fread(ptr, siz, 1, ((mik_priv_t *)r)->fh);
+}
+
+static int MIK_Get (MREADER *r)
+{
+	return FS_fgetc(((mik_priv_t *)r)->fh);
+}
+
+static BOOL MIK_Eof (MREADER *r)
+{
+	return FS_feof(((mik_priv_t *)r)->fh);
+}
+
+static qboolean S_MIKMOD_CodecInitialize (void)
+{
+	if (mikmod_codec.initialized)
+		return true;
+
+	/* set mode flags to only we like: */
+	md_mode = 0;
+	if ((shm->samplebits / 8) == 2)
+		md_mode |= DMODE_16BITS;
+	if (shm->channels == 2)
+		md_mode |= DMODE_STEREO;
+	md_mode |= DMODE_SOFT_MUSIC;	/* this is a software-only mixer */
+	md_mode |= DMODE_HQMIXER;		/* high-quality mixer is OK */
+
+	/* md_mixfreq is UWORD, so something like 96000 isn't OK */
+	md_mixfreq = (shm->speed < 65536)? shm->speed : 48000;
+
+	/* keeping md_device as 0 which is default (auto-detect: we
+	 * only register drv_nos, and it will be the only one found.)
+	 * md_pansep (stereo channels separation) default 128 is OK.
+	 * no reverbation (md_reverb 0 (up to 15)) is OK.
+	 * md_musicvolume and md_sndfxvolume defaults are 128: OK. */
+	/* just tone down overall volume md_volume from 128 to 96? */
+	md_volume = 96;
+
+	MikMod_RegisterDriver(&drv_nos);	/* only need the "nosound" driver, none else */
+	MikMod_RegisterAllLoaders();
+	if (S_MIKMOD_initlib(NULL))
+	{
+		Con_DPrintf("Could not initialize MikMod: %s\n", MikMod_strerror(MikMod_errno));
+		return false;
+	}
+
+	/* this can't get set with drv_nos, but whatever, be safe: */
+	md_mode &= ~DMODE_SIMDMIXER;	/* SIMD mixer is buggy when combined with HQMIXER */
+
+	mikmod_codec.initialized = true;
+	return true;
+}
+
+static void S_MIKMOD_CodecShutdown (void)
+{
+	if (mikmod_codec.initialized)
+	{
+		mikmod_codec.initialized = false;
+		MikMod_Exit();
+	}
+}
+
+static qboolean S_MIKMOD_CodecOpenStream (snd_stream_t *stream)
+{
+	mik_priv_t *priv;
+
+	stream->priv = Z_Malloc(sizeof(mik_priv_t));
+	priv = (mik_priv_t *) stream->priv;
+	priv->reader.Seek = MIK_Seek;
+	priv->reader.Tell = MIK_Tell;
+	priv->reader.Read = MIK_Read;
+	priv->reader.Get  = MIK_Get;
+	priv->reader.Eof  = MIK_Eof;
+	priv->fh = &stream->fh;
+
+	priv->module = Player_LoadGeneric((MREADER *)stream->priv, 64, 0);
+	if (!priv->module)
+	{
+		Con_DPrintf("Could not load module: %s\n", MikMod_strerror(MikMod_errno));
+		Z_Free(stream->priv);
+		return false;
+	}
+
+	/* keep default values of fadeout (0: don't fade out volume during when last
+	 * position of the module is being played), extspd (1: do process Protracker
+	 * extended speed effect), panflag (1: do process panning effects), wrap (0:
+	 * don't wrap to restart position when module is finished) are OK with us as
+	 * set internally by libmikmod::Player_Init(). */
+	/* just change the loop setting to 0, i.e. don't process in-module loops: */
+	priv->module->loop	= 0;
+	Player_Start(priv->module);
+
+	stream->info.rate	= md_mixfreq;
+	stream->info.bits	= (md_mode & DMODE_16BITS)? 16: 8;
+	stream->info.width	= stream->info.bits / 8;
+	stream->info.channels	= (md_mode & DMODE_STEREO)? 2 : 1;
+/*	Con_DPrintf("Playing %s (%d chn)\n", priv->module->songname, priv->module->numchn);*/
+
+	return true;
+}
+
+static int S_MIKMOD_CodecReadStream (snd_stream_t *stream, int bytes, void *buffer)
+{
+	if (!Player_Active())
+		return 0;
+	return (int) VC_WriteBytes((SBYTE *)buffer, bytes);
+}
+
+static void S_MIKMOD_CodecCloseStream (snd_stream_t *stream)
+{
+	Player_Stop();
+	Player_Free(((mik_priv_t *)stream->priv)->module);
+	Z_Free(stream->priv);
+	S_CodecUtilClose(&stream);
+}
+
+static int S_MIKMOD_CodecRewindStream (snd_stream_t *stream)
+{
+	Player_SetPosition (0);
+	return 0;
+}
+
+snd_codec_t mikmod_codec =
+{
+	CODECTYPE_MOD,
+	false,
+	"s3m",
+	S_MIKMOD_CodecInitialize,
+	S_MIKMOD_CodecShutdown,
+	S_MIKMOD_CodecOpenStream,
+	S_MIKMOD_CodecReadStream,
+	S_MIKMOD_CodecRewindStream,
+	S_MIKMOD_CodecCloseStream,
+	NULL
+};
+
+#endif	/* USE_CODEC_MIKMOD */
+

--- a/common/snd_mikmod.h
+++ b/common/snd_mikmod.h
@@ -1,0 +1,13 @@
+/* module tracker decoding support using libmikmod */
+
+#if !defined(_SND_MIKMOD_H_)
+#define _SND_MIKMOD_H_
+
+#if defined(USE_CODEC_MIKMOD)
+
+extern snd_codec_t mikmod_codec;
+
+#endif	/* USE_CODEC_MIKMOD */
+
+#endif	/* ! _SND_MIKMOD_H_ */
+

--- a/common/snd_mix.c
+++ b/common/snd_mix.c
@@ -1,5 +1,8 @@
+
 /*
-Copyright (C) 1996-1997 Id Software, Inc.
+Copyright (C) 1996-2001 Id Software, Inc.
+Copyright (C) 2010-2011 O. Sezer <sezero@users.sourceforge.net>
+Copyright (C) 2010-2014 QuakeSpasm developers
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -24,45 +27,136 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "sound.h"
 
-#define PAINTBUFFER_SIZE 512
-#define CHANNELS 2
+#define	CLAMP(_minval, x, _maxval)		\
+	((x) < (_minval) ? (_minval) :		\
+	 (x) > (_maxval) ? (_maxval) : (x))
 
+#define	PAINTBUFFER_SIZE	2048
 portable_samplepair_t paintbuffer[PAINTBUFFER_SIZE];
-int snd_scaletable[32][256];
-short *snd_out;
+int		snd_scaletable[32][256];
+int		*snd_p, snd_linear_count;
+short		*snd_out;
 
-#define CLAMP16(x) (((x) > 0x7fff) ? 0x7fff : (((x) < -0x7fff) ? -0x7fff : (x)))
+static int	snd_vol;
 
-void S_TransferPaintBuffer(int endtime)
+static void Snd_WriteLinearBlastStereo16 (void)
 {
-   int i;
-   int snd_vol = sfxvolume.value * 256;
-   int *snd_p = (int *)paintbuffer;
-   int lpaintedtime = paintedtime;
+	int		i;
+	int		val;
 
-   while (lpaintedtime < endtime)
-   {
-      // handle recirculating buffer issues
-      int lpos = lpaintedtime & ((shm->samples >> 1) - 1);
-      int snd_linear_count = (shm->samples >> 1) - lpos;
+	for (i = 0; i < snd_linear_count; i += 2)
+	{
+		val = snd_p[i] >> 8;
+		if (val > 0x7fff)
+			snd_out[i] = 0x7fff;
+		else if (val < (short)0x8000)
+			snd_out[i] = (short)0x8000;
+		else
+			snd_out[i] = val;
 
-      snd_out = (short *)shm->buffer + (lpos << 1);
-      if (lpaintedtime + snd_linear_count > endtime)
-         snd_linear_count = endtime - lpaintedtime;
-      snd_linear_count <<= 1;
-
-      // write a linear blast of samples
-      for (i = 0; i < snd_linear_count; i += 2)
-      {
-         snd_out[i]   = CLAMP16((snd_p[i]     * snd_vol) >> 8);
-         snd_out[i+1] = CLAMP16((snd_p[i + 1] * snd_vol) >> 8);
-      }
-
-      snd_p        += snd_linear_count;
-      lpaintedtime += (snd_linear_count >> 1);
-   }
+		val = snd_p[i+1] >> 8;
+		if (val > 0x7fff)
+			snd_out[i+1] = 0x7fff;
+		else if (val < (short)0x8000)
+			snd_out[i+1] = (short)0x8000;
+		else
+			snd_out[i+1] = val;
+	}
 }
 
+static void S_TransferStereo16 (int endtime)
+{
+	int		lpos;
+	int		lpaintedtime;
+
+	snd_p = (int *) paintbuffer;
+	lpaintedtime = paintedtime;
+
+	while (lpaintedtime < endtime)
+	{
+	// handle recirculating buffer issues
+		lpos = lpaintedtime & ((shm->samples >> 1) - 1);
+
+		snd_out = (short *)shm->buffer + (lpos << 1);
+
+		snd_linear_count = (shm->samples >> 1) - lpos;
+		if (lpaintedtime + snd_linear_count > endtime)
+			snd_linear_count = endtime - lpaintedtime;
+
+		snd_linear_count <<= 1;
+
+	// write a linear blast of samples
+		Snd_WriteLinearBlastStereo16 ();
+
+		snd_p += snd_linear_count;
+		lpaintedtime += (snd_linear_count >> 1);
+	}
+}
+
+static void S_TransferPaintBuffer (int endtime)
+{
+	int	out_idx, out_mask;
+	int	count, step, val;
+	int	*p;
+
+	if (shm->samplebits == 16 && shm->channels == 2)
+	{
+		S_TransferStereo16 (endtime);
+		return;
+	}
+
+	p = (int *) paintbuffer;
+	count = (endtime - paintedtime) * shm->channels;
+	out_mask = shm->samples - 1;
+	out_idx = paintedtime * shm->channels & out_mask;
+	step = 3 - shm->channels;
+
+	if (shm->samplebits == 16)
+	{
+		short *out = (short *)shm->buffer;
+		while (count--)
+		{
+			val = *p >> 8;
+			p+= step;
+			if (val > 0x7fff)
+				val = 0x7fff;
+			else if (val < (short)0x8000)
+				val = (short)0x8000;
+			out[out_idx] = val;
+			out_idx = (out_idx + 1) & out_mask;
+		}
+	}
+	else if (shm->samplebits == 8 && !shm->signed8)
+	{
+		unsigned char *out = shm->buffer;
+		while (count--)
+		{
+			val = *p >> 8;
+			p+= step;
+			if (val > 0x7fff)
+				val = 0x7fff;
+			else if (val < (short)0x8000)
+				val = (short)0x8000;
+			out[out_idx] = (val >> 8) + 128;
+			out_idx = (out_idx + 1) & out_mask;
+		}
+	}
+	else if (shm->samplebits == 8)	/* S8 format, e.g. with Amiga AHI */
+	{
+		signed char *out = (signed char *) shm->buffer;
+		while (count--)
+		{
+			val = *p >> 8;
+			p+= step;
+			if (val > 0x7fff)
+				val = 0x7fff;
+			else if (val < (short)0x8000)
+				val = (short)0x8000;
+			out[out_idx] = (val >> 8);
+			out_idx = (out_idx + 1) & out_mask;
+		}
+	}
+}
 
 /*
 ===============================================================================
@@ -72,129 +166,190 @@ CHANNEL MIXING
 ===============================================================================
 */
 
-void SND_PaintChannelFrom8(channel_t *ch, sfxcache_t *sc, int endtime);
-void SND_PaintChannelFrom16(channel_t *ch, sfxcache_t *sc, int endtime);
+static void SND_PaintChannelFrom8 (channel_t *ch, sfxcache_t *sc, int endtime, int paintbufferstart);
+static void SND_PaintChannelFrom16 (channel_t *ch, sfxcache_t *sc, int endtime, int paintbufferstart);
 
-void S_PaintChannels(int endtime)
+void S_PaintChannels (int endtime)
 {
-   int i;
-   channel_t *ch;
-   sfxcache_t *sc;
-   int ltime, count;
+	int		i;
+	int		end, ltime, count;
+	channel_t	*ch;
+	sfxcache_t	*sc;
 
-   while (paintedtime < endtime)
-   {
-      // if paintbuffer is smaller than DMA buffer
-      int end = endtime;
-      if (endtime - paintedtime > PAINTBUFFER_SIZE)
-         end = paintedtime + PAINTBUFFER_SIZE;
+	snd_vol = sfxvolume.value * 256;
 
-      // clear the paint buffer
-      memset(paintbuffer, 0,
-            (end - paintedtime) * sizeof(portable_samplepair_t));
+	while (paintedtime < endtime)
+	{
+	// if paintbuffer is smaller than DMA buffer
+		end = endtime;
+		if (endtime - paintedtime > PAINTBUFFER_SIZE)
+			end = paintedtime + PAINTBUFFER_SIZE;
 
-      // paint in the channels.
-      ch = channels;
-      for (i = 0; i < total_channels; i++, ch++)
-      {
-         if (!ch->sfx)
-            continue;
-         if (!ch->leftvol && !ch->rightvol)
-            continue;
-         sc = S_LoadSound(ch->sfx);
-         if (!sc)
-            continue;
+	// clear the paint buffer
+		memset(paintbuffer, 0, (end - paintedtime) * sizeof(portable_samplepair_t));
 
-         ltime = paintedtime;
+	// paint in the channels.
+		ch = channels;
+		for (i = 0; i < total_channels; i++, ch++)
+		{
+			if (!ch->sfx)
+				continue;
+			if (!ch->leftvol && !ch->rightvol)
+				continue;
+			sc = S_LoadSound (ch->sfx);
+			if (!sc)
+				continue;
 
-         while (ltime < end)
-         {	// paint up to end
-            if (ch->end < end)
-               count = ch->end - ltime;
-            else
-               count = end - ltime;
+			ltime = paintedtime;
 
-            if (count > 0)
-            {
-               if (sc->width == 1)
-                  SND_PaintChannelFrom8(ch, sc, count);
-               else
-                  SND_PaintChannelFrom16(ch, sc, count);
+			while (ltime < end)
+			{	// paint up to end
+				if (ch->end < end)
+					count = ch->end - ltime;
+				else
+					count = end - ltime;
 
-               ltime += count;
-            }
-            // if at end of loop, restart
-            if (ltime >= ch->end)
-            {
-               if (sc->loopstart >= 0)
-               {
-                  ch->pos = sc->loopstart;
-                  ch->end = ltime + sc->length - ch->pos;
-               }
-               else
-               {	// channel just stopped
-                  ch->sfx = NULL;
-                  break;
-               }
-            }
-         }
-      }
+				if (count > 0)
+				{
+					// the last param to SND_PaintChannelFrom is the index
+					// to start painting to in the paintbuffer, usually 0.
+					if (sc->width == 1)
+						SND_PaintChannelFrom8(ch, sc, count, ltime - paintedtime);
+					else
+						SND_PaintChannelFrom16(ch, sc, count, ltime - paintedtime);
 
-      // transfer out according to DMA format
-      S_TransferPaintBuffer(end);
-      paintedtime = end;
-   }
+					ltime += count;
+				}
+
+			// if at end of loop, restart
+				if (ltime >= ch->end)
+				{
+					if (sc->loopstart >= 0)
+					{
+						ch->pos = sc->loopstart;
+						ch->end = ltime + sc->length - ch->pos;
+					}
+					else
+					{	// channel just stopped
+						ch->sfx = NULL;
+						break;
+					}
+				}
+			}
+		}
+
+	// clip each sample to 0dB, then reduce by 6dB (to leave some headroom for
+	// the lowpass filter and the music). the lowpass will smooth out the
+	// clipping
+		for (i=0; i<end-paintedtime; i++)
+		{
+			paintbuffer[i].left = CLAMP(-32768 << 8, paintbuffer[i].left, 32767 << 8);
+			paintbuffer[i].right = CLAMP(-32768 << 8, paintbuffer[i].right, 32767 << 8);
+		}
+
+	// paint in the music
+		if (s_rawend >= paintedtime)
+		{	// copy from the streaming sound source
+			int		s;
+			int		stop;
+
+			stop = (end < s_rawend) ? end : s_rawend;
+
+			for (i = paintedtime; i < stop; i++)
+			{
+				s = i & (MAX_RAW_SAMPLES - 1);
+			// lower music by 6db to match sfx
+				paintbuffer[i - paintedtime].left += s_rawsamples[s].left;
+				paintbuffer[i - paintedtime].right += s_rawsamples[s].right;
+			}
+			//	if (i != end)
+			//		Con_Printf ("partial stream\n");
+			//	else
+			//		Con_Printf ("full stream\n");
+		}
+
+	// transfer out according to DMA format
+		S_TransferPaintBuffer(end);
+		paintedtime = end;
+	}
 }
 
-void SND_InitScaletable(void)
+void SND_InitScaletable (void)
 {
-   int i, j;
+	int		i, j;
+	int		scale;
 
-   for (i = 0; i < 32; i++)
-      for (j = 0; j < 256; j++)
-         snd_scaletable[i][j] = ((j < 128) ? j : j - 256) * i * 8;
+	for (i = 0; i < 32; i++)
+	{
+		scale = i * 8 * 256 * sfxvolume.value;
+		for (j = 0; j < 256; j++)
+		{
+		/* When compiling with gcc-4.1.0 at optimisations O1 and
+		   higher, the tricky signed char type conversion is not
+		   guaranteed. Therefore we explicity calculate the signed
+		   value from the index as required. From Kevin Shanahan.
+		   See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=26719
+		*/
+		//	snd_scaletable[i][j] = ((signed char)j) * scale;
+			snd_scaletable[i][j] = ((j < 128) ?  j : j - 256) * scale;
+		}
+	}
 }
 
-void SND_PaintChannelFrom8(channel_t *ch, sfxcache_t *sc, int count)
+
+static void SND_PaintChannelFrom8 (channel_t *ch, sfxcache_t *sc, int count, int paintbufferstart)
 {
-   int *lscale, *rscale;
-   uint8_t *sfx;
-   int i;
+	int	data;
+	int		*lscale, *rscale;
+	unsigned char	*sfx;
+	int		i;
 
-   if (ch->leftvol > 255)
-      ch->leftvol = 255;
-   if (ch->rightvol > 255)
-      ch->rightvol = 255;
+	if (ch->leftvol > 255)
+		ch->leftvol = 255;
+	if (ch->rightvol > 255)
+		ch->rightvol = 255;
 
-   lscale = snd_scaletable[ch->leftvol >> 3];
-   rscale = snd_scaletable[ch->rightvol >> 3];
-   sfx    = (uint8_t*)sc->data + ch->pos;
+	lscale = snd_scaletable[ch->leftvol >> 3];
+	rscale = snd_scaletable[ch->rightvol >> 3];
+	sfx = (unsigned char *)sc->data + ch->pos;
 
-   for (i = 0; i < count; i++)
-   {
-      int data = sfx[i];
-      paintbuffer[i].left  += lscale[data];
-      paintbuffer[i].right += rscale[data];
-   }
+	for (i = 0; i < count; i++)
+	{
+		data = sfx[i];
+		paintbuffer[paintbufferstart + i].left += lscale[data];
+		paintbuffer[paintbufferstart + i].right += rscale[data];
+	}
 
-   ch->pos += count;
+	ch->pos += count;
 }
 
-void SND_PaintChannelFrom16(channel_t *ch, sfxcache_t *sc, int count)
+static void SND_PaintChannelFrom16 (channel_t *ch, sfxcache_t *sc, int count, int paintbufferstart)
 {
-   int i;
-   int leftvol  = ch->leftvol;
-   int rightvol = ch->rightvol;
-   int16_t *sfx = (int16_t*)sc->data + ch->pos;
+	int	data;
+	int	left, right;
+	int	leftvol, rightvol;
+	signed short	*sfx;
+	int	i;
 
-   for (i = 0; i < count; i++)
-   {
-      int data              = sfx[i];
-      int left              = (data * leftvol) >> 8;
-      int right             = (data * rightvol) >> 8;
-      paintbuffer[i].left  += left;
-      paintbuffer[i].right += right;
-   }
+	leftvol = ch->leftvol * snd_vol;
+	rightvol = ch->rightvol * snd_vol;
+	leftvol >>= 8;
+	rightvol >>= 8;
+	sfx = (signed short *)sc->data + ch->pos;
 
-   ch->pos += count;
+	for (i = 0; i < count; i++)
+	{
+		data = sfx[i];
+	// this was causing integer overflow as observed in quakespasm
+	// with the warpspasm mod moved >>8 to left/right volume above.
+	//	left = (data * leftvol) >> 8;
+	//	right = (data * rightvol) >> 8;
+		left = data * leftvol;
+		right = data * rightvol;
+		paintbuffer[paintbufferstart + i].left += left;
+		paintbuffer[paintbufferstart + i].right += right;
+	}
+
+	ch->pos += count;
 }
+

--- a/common/snd_mix.c
+++ b/common/snd_mix.c
@@ -36,7 +36,7 @@ short *snd_out;
 void S_TransferPaintBuffer(int endtime)
 {
    int i;
-   int snd_vol = volume.value * 256;
+   int snd_vol = sfxvolume.value * 256;
    int *snd_p = (int *)paintbuffer;
    int lpaintedtime = paintedtime;
 

--- a/common/snd_modplug.c
+++ b/common/snd_modplug.c
@@ -1,0 +1,122 @@
+/*
+ * tracker music (module file) decoding support using libmodplug
+ *
+ * Copyright (C) 2013 O.Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "quakedef.h"
+#include "sound.h"
+
+#if defined(USE_CODEC_MODPLUG)
+#include "snd_codec.h"
+#include "snd_codeci.h"
+#include "snd_modplug.h"
+#include <libmodplug/modplug.h>
+
+static void S_MODPLUG_SetSettings (snd_stream_t *stream)
+{
+	ModPlug_Settings settings;
+
+	ModPlug_GetSettings(&settings);
+	settings.mFlags = MODPLUG_ENABLE_OVERSAMPLING;
+	settings.mChannels = shm->channels;
+	settings.mBits = shm->samplebits;
+	settings.mFrequency = shm->speed;
+	settings.mResamplingMode = MODPLUG_RESAMPLE_SPLINE;/*MODPLUG_RESAMPLE_FIR*/
+	settings.mLoopCount = 0;
+	ModPlug_SetSettings(&settings);
+
+	if (stream) {
+		stream->info.rate = shm->speed;
+		stream->info.bits = shm->samplebits;
+		stream->info.width = stream->info.bits / 8;
+		stream->info.channels = shm->channels;
+	}
+}
+
+static qboolean S_MODPLUG_CodecInitialize (void)
+{
+	return true;
+}
+
+static void S_MODPLUG_CodecShutdown (void)
+{
+}
+
+static qboolean S_MODPLUG_CodecOpenStream (snd_stream_t *stream)
+{
+/* need to load the whole file into memory and pass it to libmodplug */
+	byte *moddata;
+	long len;
+	int mark;
+
+	len = FS_filelength (&stream->fh);
+	mark = Hunk_LowMark();
+	moddata = (byte *) Hunk_Alloc(len);
+	FS_fread(moddata, 1, len, &stream->fh);
+
+	S_MODPLUG_SetSettings(stream);
+	stream->priv = ModPlug_Load(moddata, len);
+	Hunk_FreeToLowMark(mark); /* free original file data */
+	if (!stream->priv)
+	{
+		Con_DPrintf("Could not load module %s\n", stream->name);
+		return false;
+	}
+
+	ModPlug_Seek((ModPlugFile*)stream->priv, 0);
+#if 0
+	/* default volume (128) sounds rather low? */
+	ModPlug_SetMasterVolume((ModPlugFile*)stream->priv, 384);	/* 0-512 */
+#endif
+	return true;
+}
+
+static int S_MODPLUG_CodecReadStream (snd_stream_t *stream, int bytes, void *buffer)
+{
+	return ModPlug_Read((ModPlugFile*)stream->priv, buffer, bytes);
+}
+
+static void S_MODPLUG_CodecCloseStream (snd_stream_t *stream)
+{
+	ModPlug_Unload((ModPlugFile*)stream->priv);
+	S_CodecUtilClose(&stream);
+}
+
+static int S_MODPLUG_CodecRewindStream (snd_stream_t *stream)
+{
+	ModPlug_Seek((ModPlugFile*)stream->priv, 0);
+	return 0;
+}
+
+snd_codec_t modplug_codec =
+{
+	CODECTYPE_MOD,
+	true,	/* always available. */
+	"s3m",
+	S_MODPLUG_CodecInitialize,
+	S_MODPLUG_CodecShutdown,
+	S_MODPLUG_CodecOpenStream,
+	S_MODPLUG_CodecReadStream,
+	S_MODPLUG_CodecRewindStream,
+	S_MODPLUG_CodecCloseStream,
+	NULL
+};
+
+#endif	/* USE_CODEC_MODPLUG */
+

--- a/common/snd_modplug.h
+++ b/common/snd_modplug.h
@@ -1,0 +1,12 @@
+/* module tracker decoding support using libmodplug */
+#if !defined(_SND_MODPLUG_H_)
+#define _SND_MODPLUG_H_
+
+#if defined(USE_CODEC_MODPLUG)
+
+extern snd_codec_t modplug_codec;
+
+#endif	/* USE_CODEC_MODPLUG */
+
+#endif	/* ! _SND_MODPLUG_H_ */
+

--- a/common/snd_mp3.c
+++ b/common/snd_mp3.c
@@ -1,0 +1,590 @@
+/*
+ * MP3 decoding support using libmad:  Adapted from the SoX library at
+ * http://sourceforge.net/projects/sox/, LGPLv2, Copyright (c) 2007-2009
+ * SoX contributors, written by Fabrizio Gennari <fabrizio.ge@tiscali.it>,
+ * with the decoding part based on the decoder tutorial program madlld
+ * written by Bertrand Petit <madlld@phoe.fmug.org> (BSD license, see at
+ * http://www.bsd-dk.dk/~elrond/audio/madlld/).  The tag identification
+ * functions were adapted from the GPL-licensed libid3tag library, see at
+ * http://www.underbit.com/products/mad/.  Adapted to Quake and Hexen II
+ * game engines by O.Sezer :
+ * Copyright (C) 2010-2015 O.Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "quakedef.h"
+#include "sound.h"
+#include "console.h"
+#include "common.h"
+
+#if defined(USE_CODEC_MP3)
+#include "snd_codec.h"
+#include "snd_codeci.h"
+#include "snd_mp3.h"
+#include <mad.h>
+
+#define ID3_TAG_FLAG_FOOTERPRESENT 0x10
+
+/* Under Windows, importing data from DLLs is a dicey proposition. This is true
+ * when using dlopen, but also true if linking directly against the DLL if the
+ * header does not mark the data as __declspec(dllexport), which mad.h does not.
+ * Sidestep the issue by defining our own mad_timer_zero. This is needed because
+ * mad_timer_zero is used in some of the mad.h macros.
+ */
+#define mad_timer_zero mad_timer_zero_stub
+static mad_timer_t const mad_timer_zero_stub = {0, 0};
+
+/* MAD returns values with MAD_F_FRACBITS (28) bits of precision, though it's
+   not certain that all of them are meaningful. Default to 16 bits to
+   align with most users expectation of output file should be 16 bits. */
+#define MP3_MAD_SAMPLEBITS	16
+#define MP3_MAD_SAMPLEWIDTH	2
+#define MP3_BUFFER_SIZE		(5 * 8192)
+
+/* Private data */
+typedef struct _mp3_priv_t
+{
+	unsigned char mp3_buffer[MP3_BUFFER_SIZE];
+	struct mad_stream	Stream;
+	struct mad_frame	Frame;
+	struct mad_synth	Synth;
+	mad_timer_t		Timer;
+	ptrdiff_t		cursamp;
+	size_t			FrameCount;
+} mp3_priv_t;
+
+/* This function merges the functions tagtype() and id3_tag_query()
+ * from MAD's libid3tag, so we don't have to link to it
+ * Returns 0 if the frame is not an ID3 tag, tag length if it is */
+static inline qboolean tag_is_id3v1(const unsigned char *data, size_t length)
+{
+	if (length >= 3 &&
+	     data[0] == 'T' && data[1] == 'A' && data[2] == 'G')
+	{
+		return true;
+	}
+	return false;
+}
+
+static inline qboolean tag_is_id3v2(const unsigned char *data, size_t length)
+{
+	if (length >= 10 &&
+	    (data[0] == 'I' && data[1] == 'D' && data[2] == '3') &&
+	    data[3] < 0xff && data[4] < 0xff &&
+	    data[6] < 0x80 && data[7] < 0x80 && data[8] < 0x80 && data[9] < 0x80)
+	{
+		return true;
+	}
+	return false;
+}
+
+/* http://wiki.hydrogenaud.io/index.php?title=APEv1_specification
+ * http://wiki.hydrogenaud.io/index.php?title=APEv2_specification
+ * Detect an APEv2 tag. (APEv1 has no header, so no luck.)
+ */
+static inline qboolean tag_is_apetag(const unsigned char *data, size_t length)
+{
+	unsigned int v;
+
+	if (length < 32) return false;
+	if (memcmp(data,"APETAGEX",8) != 0)
+		return false;
+	v = (data[11]<<24) | (data[10]<<16) | (data[9]<<8) | data[8];
+	if (v != 2000U/* && v != 1000U*/)
+		return false;
+	v = 0;
+	if (memcmp(&data[24],&v,4) != 0 || memcmp(&data[28],&v,4) != 0)
+		return false;
+	return true;
+}
+
+static size_t mp3_tagsize(const unsigned char *data, size_t length)
+{
+	size_t size;
+
+	if (tag_is_id3v1(data, length))
+		return 128;
+
+	if (tag_is_id3v2(data, length))
+	{
+		unsigned char flags = data[5];
+		size = 10 + (data[6]<<21) + (data[7]<<14) + (data[8]<<7) + data[9];
+		if (flags & ID3_TAG_FLAG_FOOTERPRESENT)
+			size += 10;
+		for ( ; size < length && !data[size]; ++size)
+			;  /* Consume padding */
+		return size;
+	}
+
+	if (tag_is_apetag(data, length))
+	{
+		size = (data[15]<<24) | (data[14]<<16) | (data[13]<<8) | data[12];
+		size += 32;
+		return size;
+	}
+
+	return 0;
+}
+
+/* Attempts to read an ID3 tag at the current location in stream and
+ * consume it all.  Returns -1 if no tag is found.  Its up to caller
+ * to recover.  */
+static int mp3_inputtag(snd_stream_t *stream)
+{
+	mp3_priv_t *p = (mp3_priv_t *) stream->priv;
+	int rc = -1;
+	size_t remaining;
+	size_t tagsize;
+
+	/* FIXME: This needs some more work if we are to ever
+	 * look at the ID3 frame.  This is because the Stream
+	 * may not be able to hold the complete ID3 frame.
+	 * We should consume the whole frame inside tagtype()
+	 * instead of outside of tagframe().  That would support
+	 * recovering when Stream contains less then 8-bytes (header)
+	 * and also when ID3v2 is bigger then Stream buffer size.
+	 * Need to pass in stream so that buffer can be
+	 * consumed as well as letting additional data to be
+	 * read in.
+	 */
+	remaining = p->Stream.bufend - p->Stream.next_frame;
+	tagsize = mp3_tagsize(p->Stream.this_frame, remaining);
+	if (tagsize != 0)
+	{
+		mad_stream_skip(&p->Stream, tagsize);
+		rc = 0;
+	}
+
+	/* We know that a valid frame hasn't been found yet
+	 * so help libmad out and go back into frame seek mode.
+	 * This is true whether an ID3 tag was found or not.
+	 */
+	mad_stream_sync(&p->Stream);
+
+	return rc;
+}
+
+/* (Re)fill the stream buffer that is to be decoded.  If any data
+ * still exists in the buffer then they are first shifted to be
+ * front of the stream buffer.  */
+static int mp3_inputdata(snd_stream_t *stream)
+{
+	mp3_priv_t *p = (mp3_priv_t *) stream->priv;
+	size_t bytes_read;
+	size_t remaining;
+
+	remaining = p->Stream.bufend - p->Stream.next_frame;
+
+	/* libmad does not consume all the buffer it's given. Some
+	 * data, part of a truncated frame, is left unused at the
+	 * end of the buffer. That data must be put back at the
+	 * beginning of the buffer and taken in account for
+	 * refilling the buffer. This means that the input buffer
+	 * must be large enough to hold a complete frame at the
+	 * highest observable bit-rate (currently 448 kb/s).
+	 * TODO: Is 2016 bytes the size of the largest frame?
+	 * (448000*(1152/32000))/8
+	 */
+	memmove(p->mp3_buffer, p->Stream.next_frame, remaining);
+
+	bytes_read = FS_fread(p->mp3_buffer + remaining, 1,
+				MP3_BUFFER_SIZE - remaining, &stream->fh);
+	if (bytes_read == 0)
+		return -1;
+
+	mad_stream_buffer(&p->Stream, p->mp3_buffer, bytes_read+remaining);
+	p->Stream.error = MAD_ERROR_NONE;
+
+	return 0;
+}
+
+static int mp3_startread(snd_stream_t *stream)
+{
+	mp3_priv_t *p = (mp3_priv_t *) stream->priv;
+	size_t ReadSize;
+
+	mad_stream_init(&p->Stream);
+	mad_frame_init(&p->Frame);
+	mad_synth_init(&p->Synth);
+	mad_timer_reset(&p->Timer);
+
+	/* Decode at least one valid frame to find out the input
+	 * format.  The decoded frame will be saved off so that it
+	 * can be processed later.
+	 */
+	ReadSize = FS_fread(p->mp3_buffer, 1, MP3_BUFFER_SIZE, &stream->fh);
+	if (!ReadSize || FS_ferror(&stream->fh))
+		return -1;
+
+	mad_stream_buffer(&p->Stream, p->mp3_buffer, ReadSize);
+
+	/* Find a valid frame before starting up.  This makes sure
+	 * that we have a valid MP3 and also skips past ID3v2 tags
+	 * at the beginning of the audio file.
+	 */
+	p->Stream.error = MAD_ERROR_NONE;
+	while (mad_frame_decode(&p->Frame,&p->Stream))
+	{
+		/* check whether input buffer needs a refill */
+		if (p->Stream.error == MAD_ERROR_BUFLEN)
+		{
+			if (mp3_inputdata(stream) == -1)
+				return -1;/* EOF with no valid data */
+
+			continue;
+		}
+
+		/* Consume any ID3 tags */
+		mp3_inputtag(stream);
+
+		/* FIXME: We should probably detect when we've read
+		 * a bunch of non-ID3 data and still haven't found a
+		 * frame.  In that case we can abort early without
+		 * scanning the whole file.
+		 */
+		p->Stream.error = MAD_ERROR_NONE;
+	}
+
+	if (p->Stream.error)
+	{
+		Con_Printf("MP3: No valid MP3 frame found\n");
+		return -1;
+	}
+
+	switch(p->Frame.header.mode)
+	{
+	case MAD_MODE_SINGLE_CHANNEL:
+	case MAD_MODE_DUAL_CHANNEL:
+	case MAD_MODE_JOINT_STEREO:
+	case MAD_MODE_STEREO:
+		stream->info.channels = MAD_NCHANNELS(&p->Frame.header);
+		break;
+	default:
+		Con_Printf("MP3: Cannot determine number of channels\n");
+		return -1;
+	}
+
+	p->FrameCount = 1;
+
+	mad_timer_add(&p->Timer,p->Frame.header.duration);
+	mad_synth_frame(&p->Synth,&p->Frame);
+	stream->info.rate = p->Synth.pcm.samplerate;
+	stream->info.bits = MP3_MAD_SAMPLEBITS;
+	stream->info.width = MP3_MAD_SAMPLEWIDTH;
+
+	p->cursamp = 0;
+
+	return 0;
+}
+
+/* Read up to len samples from p->Synth
+ * If needed, read some more MP3 data, decode them and synth them
+ * Place in buf[].
+ * Return number of samples read.  */
+static int mp3_decode(snd_stream_t *stream, byte *buf, int len)
+{
+	mp3_priv_t *p = (mp3_priv_t *) stream->priv;
+	int donow, i, done = 0;
+	mad_fixed_t sample;
+	int chan, x;
+
+	do
+	{
+		x = (p->Synth.pcm.length - p->cursamp) * stream->info.channels;
+		donow = qmin(len, x);
+		i = 0;
+		while (i < donow)
+		{
+			for (chan = 0; chan < stream->info.channels; chan++)
+			{
+				sample = p->Synth.pcm.samples[chan][p->cursamp];
+				/* convert from fixed to short,
+				 * write in host-endian format. */
+				if (sample <= -MAD_F_ONE)
+					sample = -0x7FFF;
+				else if (sample >= MAD_F_ONE)
+					sample = 0x7FFF;
+				else
+					sample >>= (MAD_F_FRACBITS + 1 - 16);
+				if (bigendien)
+				{
+					*buf++ = (sample >> 8) & 0xFF;
+					*buf++ = sample & 0xFF;
+				}
+				else /* assumed LITTLE_ENDIAN. */
+				{
+					*buf++ = sample & 0xFF;
+					*buf++ = (sample >> 8) & 0xFF;
+				}
+				i++;
+			}
+			p->cursamp++;
+		}
+
+		len -= donow;
+		done += donow;
+
+		if (len == 0)
+			break;
+
+		/* check whether input buffer needs a refill */
+		if (p->Stream.error == MAD_ERROR_BUFLEN)
+		{
+			if (mp3_inputdata(stream) == -1)
+			{
+				/* check feof() ?? */
+				Con_DPrintf("mp3 EOF\n");
+				break;
+			}
+		}
+
+		if (mad_frame_decode(&p->Frame, &p->Stream))
+		{
+			if (MAD_RECOVERABLE(p->Stream.error))
+			{
+				mp3_inputtag(stream);
+				continue;
+			}
+			else
+			{
+				if (p->Stream.error == MAD_ERROR_BUFLEN)
+					continue;
+				else
+				{
+					Con_Printf("MP3: unrecoverable frame level error (%s)\n",
+							mad_stream_errorstr(&p->Stream));
+					break;
+				}
+			}
+		}
+		p->FrameCount++;
+		mad_timer_add(&p->Timer, p->Frame.header.duration);
+		mad_synth_frame(&p->Synth, &p->Frame);
+		p->cursamp = 0;
+	} while (1);
+
+	return done;
+}
+
+static int mp3_stopread(snd_stream_t *stream)
+{
+	mp3_priv_t *p = (mp3_priv_t*) stream->priv;
+
+	mad_synth_finish(&p->Synth);
+	mad_frame_finish(&p->Frame);
+	mad_stream_finish(&p->Stream);
+
+	return 0;
+}
+
+static int mp3_madseek(snd_stream_t *stream, unsigned long offset)
+{
+	mp3_priv_t *p = (mp3_priv_t *) stream->priv;
+	size_t   initial_bitrate = p->Frame.header.bitrate;
+	size_t   tagsize = 0, consumed = 0;
+	int vbr = 0;		/* Variable Bit Rate, bool */
+	qboolean depadded = false;
+	unsigned long to_skip_samples = 0;
+
+	/* Reset all */
+	FS_rewind(&stream->fh);
+	mad_timer_reset(&p->Timer);
+	p->FrameCount = 0;
+
+	/* They where opened in startread */
+	mad_synth_finish(&p->Synth);
+	mad_frame_finish(&p->Frame);
+	mad_stream_finish(&p->Stream);
+
+	mad_stream_init(&p->Stream);
+	mad_frame_init(&p->Frame);
+	mad_synth_init(&p->Synth);
+
+	offset /= stream->info.channels;
+	to_skip_samples = offset;
+
+	while (1)	/* Read data from the MP3 file */
+	{
+		int bytes_read, padding = 0;
+		size_t leftover = p->Stream.bufend - p->Stream.next_frame;
+
+		memcpy(p->mp3_buffer, p->Stream.this_frame, leftover);
+		bytes_read = FS_fread(p->mp3_buffer + leftover, (size_t) 1,
+					MP3_BUFFER_SIZE - leftover, &stream->fh);
+		if (bytes_read <= 0)
+		{
+			Con_DPrintf("seek failure. unexpected EOF (frames=%lu leftover=%lu)\n",
+					(unsigned long)p->FrameCount, (unsigned long)leftover);
+			break;
+		}
+		for ( ; !depadded && padding < bytes_read && !p->mp3_buffer[padding]; ++padding)
+			;
+		depadded = true;
+		mad_stream_buffer(&p->Stream, p->mp3_buffer + padding, leftover + bytes_read - padding);
+
+		while (1)	/* Decode frame headers */
+		{
+			static unsigned short samples;
+			p->Stream.error = MAD_ERROR_NONE;
+
+			/* Not an audio frame */
+			if (mad_header_decode(&p->Frame.header, &p->Stream) == -1)
+			{
+				if (p->Stream.error == MAD_ERROR_BUFLEN)
+					break;	/* Normal behaviour; get some more data from the file */
+				if (!MAD_RECOVERABLE(p->Stream.error))
+				{
+					Con_DPrintf("unrecoverable MAD error\n");
+					break;
+				}
+				if (p->Stream.error == MAD_ERROR_LOSTSYNC)
+				{
+					unsigned long available = (p->Stream.bufend - p->Stream.this_frame);
+					tagsize = mp3_tagsize(p->Stream.this_frame, (size_t) available);
+					if (tagsize)
+					{	/* It's some ID3 tags, so just skip */
+						if (tagsize >= available)
+						{
+							FS_fseek(&stream->fh, (long)(tagsize - available), SEEK_CUR);
+							depadded = false;
+						}
+						mad_stream_skip(&p->Stream, qmin(tagsize, available));
+					}
+					else
+					{
+						Con_DPrintf("MAD lost sync\n");
+					}
+				}
+				else
+				{
+					Con_DPrintf("recoverable MAD error\n");
+				}
+				continue;
+			}
+
+			consumed +=  p->Stream.next_frame - p->Stream.this_frame;
+			vbr      |= (p->Frame.header.bitrate != initial_bitrate);
+
+			samples = 32 * MAD_NSBSAMPLES(&p->Frame.header);
+
+			p->FrameCount++;
+			mad_timer_add(&p->Timer, p->Frame.header.duration);
+
+			if (to_skip_samples <= samples)
+			{
+				mad_frame_decode(&p->Frame,&p->Stream);
+				mad_synth_frame(&p->Synth, &p->Frame);
+				p->cursamp = to_skip_samples;
+				return 0;
+			}
+			else	to_skip_samples -= samples;
+
+			/* If not VBR, we can extrapolate frame size */
+			if (p->FrameCount == 64 && !vbr)
+			{
+				p->FrameCount = offset / samples;
+				to_skip_samples = offset % samples;
+				if (0 != FS_fseek(&stream->fh, (p->FrameCount * consumed / 64) + tagsize, SEEK_SET))
+					return -1;
+
+				/* Reset Stream for refilling buffer */
+				mad_stream_finish(&p->Stream);
+				mad_stream_init(&p->Stream);
+				break;
+			}
+		}
+	}
+
+	return -1;
+}
+
+static qboolean S_MP3_CodecInitialize (void)
+{
+	return true;
+}
+
+static void S_MP3_CodecShutdown (void)
+{
+}
+
+static qboolean S_MP3_CodecOpenStream (snd_stream_t *stream)
+{
+	int err;
+
+	stream->priv = calloc(1, sizeof(mp3_priv_t));
+	if (!stream->priv)
+	{
+		Con_Printf("Insufficient memory for MP3 audio\n");
+		return false;
+	}
+	err = mp3_startread(stream);
+	if (err != 0)
+	{
+		Con_Printf("%s is not a valid mp3 file\n", stream->name);
+	}
+	else if (stream->info.channels != 1 && stream->info.channels != 2)
+	{
+		Con_Printf("Unsupported number of channels %d in %s\n",
+					stream->info.channels, stream->name);
+	}
+	else
+	{
+		return true;
+	}
+	free(stream->priv);
+	return false;
+}
+
+static int S_MP3_CodecReadStream (snd_stream_t *stream, int bytes, void *buffer)
+{
+	int res = mp3_decode(stream, (byte *)buffer, bytes / stream->info.width);
+	return res * stream->info.width;
+}
+
+static void S_MP3_CodecCloseStream (snd_stream_t *stream)
+{
+	mp3_stopread(stream);
+	free(stream->priv);
+	S_CodecUtilClose(&stream);
+}
+
+static int S_MP3_CodecRewindStream (snd_stream_t *stream)
+{
+	/*
+	mp3_stopread(stream);
+	FS_rewind(&stream->fh);
+	return mp3_startread(stream);
+	*/
+	return mp3_madseek(stream, 0);
+}
+
+snd_codec_t mp3_codec =
+{
+	CODECTYPE_MP3,
+	true,	/* always available. */
+	"mp3",
+	S_MP3_CodecInitialize,
+	S_MP3_CodecShutdown,
+	S_MP3_CodecOpenStream,
+	S_MP3_CodecReadStream,
+	S_MP3_CodecRewindStream,
+	S_MP3_CodecCloseStream,
+	NULL
+};
+
+#endif	/* USE_CODEC_MP3 */
+

--- a/common/snd_mp3.h
+++ b/common/snd_mp3.h
@@ -1,0 +1,13 @@
+/* MP3 decoding support using libmad or libmpg123. */
+
+#if !defined(_SND_MP3_H_)
+#define _SND_MP3_H_
+
+#if defined(USE_CODEC_MP3)
+
+extern snd_codec_t mp3_codec;
+
+#endif	/* USE_CODEC_MP3 */
+
+#endif	/* ! _SND_MP3_H_ */
+

--- a/common/snd_mpg123.c
+++ b/common/snd_mpg123.c
@@ -1,0 +1,227 @@
+/*
+ * MP3 decoding support using libmpg123, loosely based on an SDL_mixer
+ * See: http://bubu.lv/changeset/4/public/libs/SDL/generated/SDL_mixer
+ *
+ * Copyright (C) 2011-2012 O.Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "quakedef.h"
+#include "sound.h"
+
+#if defined(USE_CODEC_MP3)
+#include "snd_codec.h"
+#include "snd_codeci.h"
+#include "snd_mp3.h"
+#include <errno.h>
+#include <mpg123.h>
+
+#if !defined(MPG123_API_VERSION) || (MPG123_API_VERSION < 24)
+#error minimum required libmpg123 version is 1.12.0 (api version 24)
+#endif	/* MPG123_API_VERSION */
+
+/* Private data */
+typedef struct _mp3_priv_t
+{
+	int handle_newed, handle_opened;
+	mpg123_handle* handle;
+} mp3_priv_t;
+
+/* CALLBACK FUNCTIONS: */
+/* CAREFUL: libmpg123 expects POSIX read() and lseek() behavior,
+ * however our FS_fread() and FS_fseek() return fread() and fseek()
+ * compatible values.  */
+
+static ssize_t mp3_read (void *f, void *buf, size_t size)
+{
+	ssize_t ret = (ssize_t) FS_fread(buf, 1, size, (fshandle_t *)f);
+	if (ret == 0 && errno != 0)
+		ret = -1;
+	return ret;
+}
+
+static off_t mp3_seek (void *f, off_t offset, int whence)
+{
+	if (f == NULL) return (-1);
+	if (FS_fseek((fshandle_t *)f, (long) offset, whence) < 0)
+		return (off_t)-1;
+	return (off_t) FS_ftell((fshandle_t *)f);
+}
+
+static qboolean S_MP3_CodecInitialize (void)
+{
+	if (!mp3_codec.initialized)
+	{
+		if (mpg123_init() != MPG123_OK)
+		{
+			Con_Printf ("Could not initialize mpg123\n");
+			return false;
+		}
+		mp3_codec.initialized = true;
+		return true;
+	}
+
+	return true;
+}
+
+static void S_MP3_CodecShutdown (void)
+{
+	if (mp3_codec.initialized)
+	{
+		mp3_codec.initialized = false;
+		mpg123_exit();
+	}
+}
+
+static qboolean S_MP3_CodecOpenStream (snd_stream_t *stream)
+{
+	long rate = 0;
+	int encoding = 0, channels = 0;
+	mp3_priv_t *priv = NULL;
+
+	stream->priv = Z_Malloc(sizeof(mp3_priv_t));
+	priv = (mp3_priv_t *) stream->priv;
+	priv->handle = mpg123_new(NULL, NULL);
+	if (priv->handle == NULL)
+	{
+		Con_Printf("Unable to allocate mpg123 handle\n");
+		goto _fail;
+	}
+	priv->handle_newed = 1;
+
+	if (mpg123_replace_reader_handle(priv->handle, mp3_read, mp3_seek, NULL) != MPG123_OK ||
+	    mpg123_open_handle(priv->handle, &stream->fh) != MPG123_OK)
+	{
+		Con_Printf("Unable to open mpg123 handle\n");
+		goto _fail;
+	}
+	priv->handle_opened = 1;
+
+	if (mpg123_getformat(priv->handle, &rate, &channels, &encoding) != MPG123_OK)
+	{
+		Con_Printf("Unable to retrieve mpg123 format for %s\n", stream->name);
+		goto _fail;
+	}
+
+	switch (channels)
+	{
+	case MPG123_MONO:
+		stream->info.channels = 1;
+		break;
+	case MPG123_STEREO:
+		stream->info.channels = 2;
+		break;
+	default:
+		Con_Printf("Unsupported number of channels %d in %s\n", channels, stream->name);
+		goto _fail;
+	}
+
+	stream->info.rate = rate;
+
+	switch (encoding)
+	{
+	case MPG123_ENC_UNSIGNED_8:
+		stream->info.bits = 8;
+		stream->info.width = 1;
+		break;
+	case MPG123_ENC_SIGNED_8:
+	/* unsupported: force mpg123 to convert */
+		stream->info.bits = 8;
+		stream->info.width = 1;
+		encoding = MPG123_ENC_UNSIGNED_8;
+		break;
+	case MPG123_ENC_SIGNED_16:
+		stream->info.bits = 16;
+		stream->info.width = 2;
+		break;
+	case MPG123_ENC_UNSIGNED_16:
+	default:
+	/* unsupported: force mpg123 to convert */
+		stream->info.bits = 16;
+		stream->info.width = 2;
+		encoding = MPG123_ENC_SIGNED_16;
+		break;
+	}
+	if (mpg123_format_support(priv->handle, rate, encoding) == 0)
+	{
+		Con_Printf("Unsupported format for %s\n", stream->name);
+		goto _fail;
+	}
+	mpg123_format_none(priv->handle);
+	mpg123_format(priv->handle, rate, channels, encoding);
+
+	return true;
+_fail:
+	if (priv)
+	{
+		if (priv->handle_opened)
+			mpg123_close(priv->handle);
+		if (priv->handle_newed)
+			mpg123_delete(priv->handle);
+		Z_Free(stream->priv);
+	}
+	return false;
+}
+
+static int S_MP3_CodecReadStream (snd_stream_t *stream, int bytes, void *buffer)
+{
+	mp3_priv_t *priv = (mp3_priv_t *) stream->priv;
+	size_t bytes_read = 0;
+	int res = mpg123_read (priv->handle, (unsigned char *)buffer, (size_t)bytes, &bytes_read);
+	switch (res)
+	{
+	case MPG123_DONE:
+		Con_DPrintf("mp3 EOF\n");
+	case MPG123_OK:
+		return (int)bytes_read;
+	}
+	return -1; /* error */
+}
+
+static void S_MP3_CodecCloseStream (snd_stream_t *stream)
+{
+	mp3_priv_t *priv = (mp3_priv_t *) stream->priv;
+	mpg123_close(priv->handle);
+	mpg123_delete(priv->handle);
+	Z_Free(stream->priv);
+	S_CodecUtilClose(&stream);
+}
+
+static int S_MP3_CodecRewindStream (snd_stream_t *stream)
+{
+	mp3_priv_t *priv = (mp3_priv_t *) stream->priv;
+	off_t res = mpg123_seek(priv->handle, 0, SEEK_SET);
+	if (res >= 0) return (0);
+	return res;
+}
+
+snd_codec_t mp3_codec =
+{
+	CODECTYPE_MP3,
+	false,
+	"mp3",
+	S_MP3_CodecInitialize,
+	S_MP3_CodecShutdown,
+	S_MP3_CodecOpenStream,
+	S_MP3_CodecReadStream,
+	S_MP3_CodecRewindStream,
+	S_MP3_CodecCloseStream,
+	NULL
+};
+
+#endif	/* USE_CODEC_MP3 */
+

--- a/common/snd_opus.c
+++ b/common/snd_opus.c
@@ -1,0 +1,211 @@
+/*
+ * Ogg/Opus streaming music support, loosely based on several open source
+ * Quake engine based projects with many modifications.
+ *
+ * Copyright (C) 2012-2013 O.Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "quakedef.h"
+#include "sound.h"
+
+#if defined(USE_CODEC_OPUS)
+#include "snd_codec.h"
+#include "snd_codeci.h"
+#include "snd_opus.h"
+
+#include <errno.h>
+#include <opusfile.h>
+
+
+/* CALLBACK FUNCTIONS: */
+
+static int opc_fclose (void *f)
+{
+	return 0;		/* we fclose() elsewhere. */
+}
+
+static int opc_fread (void *f, unsigned char *buf, int size)
+{
+	int ret;
+
+	if (size < 0)
+	{
+		errno = EINVAL;
+		return -1;
+	}
+
+	ret = (int) FS_fread(buf, 1, (size_t)size, (fshandle_t *)f);
+	if (ret == 0 && errno != 0)
+		ret = -1;
+	return ret;
+}
+
+static int opc_fseek (void *f, opus_int64 off, int whence)
+{
+	if (f == NULL) return (-1);
+	return FS_fseek((fshandle_t *)f, (long) off, whence);
+}
+
+static opus_int64 opc_ftell (void *f)
+{
+	return (opus_int64) FS_ftell((fshandle_t *)f);
+}
+
+static const OpusFileCallbacks opc_qfs =
+{
+	(int (*)(void *, unsigned char *, int)) opc_fread,
+	(int (*)(void *, opus_int64, int))	opc_fseek,
+	(opus_int64 (*)(void *))		opc_ftell,
+	(int (*)(void *))			opc_fclose
+};
+
+static qboolean S_OPUS_CodecInitialize (void)
+{
+	return true;
+}
+
+static void S_OPUS_CodecShutdown (void)
+{
+}
+
+static qboolean S_OPUS_CodecOpenStream (snd_stream_t *stream)
+{
+	OggOpusFile *opFile;
+	const OpusHead *op_info;
+	long numstreams;
+	int res;
+
+	opFile = op_open_callbacks(&stream->fh, &opc_qfs, NULL, 0, &res);
+	if (!opFile)
+	{
+		Con_Printf("%s is not a valid Opus file (error %i).\n",
+				stream->name, res);
+		goto _fail;
+	}
+
+	stream->priv = opFile;
+
+	if (!op_seekable(opFile))
+	{
+		Con_Printf("Opus stream %s not seekable.\n", stream->name);
+		goto _fail;
+	}
+
+	op_info = op_head(opFile, -1);
+	if (!op_info)
+	{
+		Con_Printf("Unable to get stream information for %s.\n", stream->name);
+		goto _fail;
+	}
+
+	/* FIXME: handle section changes */
+	numstreams = op_info->stream_count;
+	if (numstreams != 1)
+	{
+		Con_Printf("More than one (%ld) stream in %s\n",
+					(long)op_info->stream_count, stream->name);
+		goto _fail;
+	}
+
+	if (op_info->channel_count != 1 && op_info->channel_count != 2)
+	{
+		Con_Printf("Unsupported number of channels %d in %s\n",
+					op_info->channel_count, stream->name);
+		goto _fail;
+	}
+
+	/* All Opus audio is coded at 48 kHz, and should also be decoded
+	 * at 48 kHz for playback: info->input_sample_rate only tells us
+	 * the sampling rate of the original input before opus encoding.
+	 * S_RawSamples() shall already downsample this, as necessary.  */
+	stream->info.rate = 48000;
+	stream->info.channels = op_info->channel_count;
+	/* op_read() yields 16-bit output using native endian ordering: */
+	stream->info.bits = 16;
+	stream->info.width = 2;
+
+	return true;
+_fail:
+	if (opFile)
+		op_free(opFile);
+	return false;
+}
+
+static int S_OPUS_CodecReadStream (snd_stream_t *stream, int bytes, void *buffer)
+{
+	int	section;	/* FIXME: handle section changes */
+	int	cnt, res, rem;
+	opus_int16 *	ptr;
+
+	rem = bytes / stream->info.width;
+	if (rem / stream->info.channels <= 0)
+		return 0;
+
+	cnt = 0;
+	ptr = (opus_int16 *) buffer;
+	while (1)
+	{
+	/* op_read() yields 16-bit output using native endian ordering. returns
+	 * the number of samples read per channel on success, or a negative value
+	 * on failure. */
+		res = op_read((OggOpusFile *)stream->priv, ptr, rem, &section);
+		if (res <= 0)
+			break;
+		cnt += res;
+		res *= stream->info.channels;
+		rem -= res;
+		if (rem <= 0)
+			break;
+		ptr += res;
+	}
+
+	if (res < 0)
+		return res;
+
+	cnt *= (stream->info.channels * stream->info.width);
+	return cnt;
+}
+
+static void S_OPUS_CodecCloseStream (snd_stream_t *stream)
+{
+	op_free((OggOpusFile *)stream->priv);
+	S_CodecUtilClose(&stream);
+}
+
+static int S_OPUS_CodecRewindStream (snd_stream_t *stream)
+{
+	return op_pcm_seek ((OggOpusFile *)stream->priv, 0);
+}
+
+snd_codec_t opus_codec =
+{
+	CODECTYPE_OPUS,
+	true,	/* always available. */
+	"opus",
+	S_OPUS_CodecInitialize,
+	S_OPUS_CodecShutdown,
+	S_OPUS_CodecOpenStream,
+	S_OPUS_CodecReadStream,
+	S_OPUS_CodecRewindStream,
+	S_OPUS_CodecCloseStream,
+	NULL
+};
+
+#endif	/* USE_CODEC_OPUS */
+

--- a/common/snd_opus.h
+++ b/common/snd_opus.h
@@ -1,0 +1,13 @@
+/* Ogg/Opus streaming music support. */
+
+#if !defined(_SND_OPUS_H_)
+#define _SND_OPUS_H_ 1
+
+#if defined(USE_CODEC_OPUS)
+
+extern snd_codec_t opus_codec;
+
+#endif	/* USE_CODEC_OPUS */
+
+#endif	/* ! _SND_OPUS_H_ */
+

--- a/common/snd_umx.c
+++ b/common/snd_umx.c
@@ -1,0 +1,408 @@
+/*
+ * Unreal UMX container support.
+ * UPKG parsing partially based on Unreal Media Ripper (UMR) v0.3
+ * by Andy Ward <wardwh@swbell.net>, with additional updates
+ * by O. Sezer - see git repo at https://github.com/sezero/umr/
+ *
+ * The cheaper way, i.e. linear search of music object like libxmp
+ * and libmodplug does, is possible. With this however we're using
+ * the embedded offset, size and object type directly from the umx
+ * file, and I feel safer with it.
+ *
+ * Copyright (C) 2013 O. Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "quakedef.h"
+#include "sound.h"
+
+#if defined(USE_CODEC_UMX)
+#include "snd_codec.h"
+#include "snd_codeci.h"
+#include "snd_umx.h"
+
+typedef int32_t fci_t;		/* FCompactIndex */
+
+#define UPKG_HDR_TAG	0x9e2a83c1
+
+struct _genhist {	/* for upkg versions >= 68 */
+	int32_t export_count;
+	int32_t name_count;
+};
+
+struct upkg_hdr {
+	uint32_t tag;	/* UPKG_HDR_TAG */
+	int32_t file_version;
+	uint32_t pkg_flags;
+	int32_t name_count;	/* number of names in name table (>= 0) */
+	int32_t name_offset;		/* offset to name table  (>= 0) */
+	int32_t export_count;	/* num. exports in export table  (>= 0) */
+	int32_t export_offset;		/* offset to export table (>= 0) */
+	int32_t import_count;	/* num. imports in export table  (>= 0) */
+	int32_t import_offset;		/* offset to import table (>= 0) */
+
+	/* number of GUIDs in heritage table (>= 1) and table's offset:
+	 * only with versions < 68. */
+	int32_t heritage_count;
+	int32_t heritage_offset;
+	/* with versions >= 68:  a GUID, a dword for generation count
+	 * and export_count and name_count dwords for each generation: */
+	uint32_t guid[4];
+	int32_t generation_count;
+#define UPKG_HDR_SIZE 64			/* 64 bytes up until here */
+	/*struct _genhist *gen;*/
+};
+/*COMPILE_TIME_ASSERT(upkg_hdr, offsetof(struct upkg_hdr, gen) == UPKG_HDR_SIZE);*/
+COMPILE_TIME_ASSERT(upkg_hdr, sizeof(struct upkg_hdr) == UPKG_HDR_SIZE);
+
+#define UMUSIC_IT	0
+#define UMUSIC_S3M	1
+#define UMUSIC_XM	2
+#define UMUSIC_MOD	3
+#define UMUSIC_WAV	4
+#define UMUSIC_MP2	5
+
+static const char *mustype[] = {
+	"IT", "S3M", "XM", "MOD",
+	"WAV", "MP2", NULL
+};
+
+/* decode an FCompactIndex.
+ * original documentation by Tim Sweeney was at
+ * http://unreal.epicgames.com/Packages.htm
+ * also see Unreal Wiki:
+ * http://wiki.beyondunreal.com/Legacy:Package_File_Format/Data_Details
+ */
+static fci_t get_fci (const char *in, int *pos)
+{
+	int32_t a;
+	int size;
+
+	size = 1;
+	a = in[0] & 0x3f;
+
+	if (in[0] & 0x40) {
+		size++;
+		a |= (in[1] & 0x7f) << 6;
+
+		if (in[1] & 0x80) {
+			size++;
+			a |= (in[2] & 0x7f) << 13;
+
+			if (in[2] & 0x80) {
+				size++;
+				a |= (in[3] & 0x7f) << 20;
+
+				if (in[3] & 0x80) {
+					size++;
+					a |= (in[4] & 0x3f) << 27;
+				}
+			}
+		}
+	}
+
+	if (in[0] & 0x80)
+		a = -a;
+
+	*pos += size;
+
+	return a;
+}
+
+static int get_objtype (fshandle_t *f, int32_t ofs, int type)
+{
+	char sig[16];
+_retry:
+	FS_fseek(f, ofs, SEEK_SET);
+	FS_fread(sig, 16, 1, f);
+	if (type == UMUSIC_IT) {
+		if (memcmp(sig, "IMPM", 4) == 0)
+			return UMUSIC_IT;
+		return -1;
+	}
+	if (type == UMUSIC_XM) {
+		if (memcmp(sig, "Extended Module:", 16) != 0)
+			return -1;
+		FS_fread(sig, 16, 1, f);
+		if (sig[0] != ' ') return -1;
+		FS_fread(sig, 16, 1, f);
+		if (sig[5] != 0x1a) return -1;
+		return UMUSIC_XM;
+	}
+	if (type == UMUSIC_MP2) {
+		unsigned char *p = (unsigned char *)sig;
+		uint16_t u = ((p[0] << 8) | p[1]) & 0xFFFE;
+		if (u == 0xFFFC || u == 0xFFF4)
+			return UMUSIC_MP2;
+		return -1;
+	}
+	if (type == UMUSIC_WAV) {
+		if (memcmp(sig, "RIFF", 4) == 0 && memcmp(&sig[8], "WAVE", 4) == 0)
+			return UMUSIC_WAV;
+		return -1;
+	}
+
+	FS_fseek(f, ofs + 44, SEEK_SET);
+	FS_fread(sig, 4, 1, f);
+	if (type == UMUSIC_S3M) {
+		if (memcmp(sig, "SCRM", 4) == 0)
+			return UMUSIC_S3M;
+		/*return -1;*/
+		/* SpaceMarines.umx and Starseek.umx from Return to NaPali
+		 * report as "s3m" whereas the actual music format is "it" */
+		type = UMUSIC_IT;
+		goto _retry;
+	}
+
+	FS_fseek(f, ofs + 1080, SEEK_SET);
+	FS_fread(sig, 4, 1, f);
+	if (type == UMUSIC_MOD) {
+		if (memcmp(sig, "M.K.", 4) == 0 || memcmp(sig, "M!K!", 4) == 0)
+			return UMUSIC_MOD;
+		return -1;
+	}
+
+	return -1;
+}
+
+static int read_export (fshandle_t *f, const struct upkg_hdr *hdr,
+			int32_t *ofs, int32_t *objsize)
+{
+	char buf[40];
+	int idx = 0, t;
+
+	FS_fseek(f, *ofs, SEEK_SET);
+	if (FS_fread(buf, 4, 10, f) < 10)
+		return -1;
+
+	if (hdr->file_version < 40) idx += 8;	/* 00 00 00 00 00 00 00 00 */
+	if (hdr->file_version < 60) idx += 16;	/* 81 00 00 00 00 00 FF FF FF FF FF FF FF FF 00 00 */
+	get_fci(&buf[idx], &idx);		/* skip junk */
+	t = get_fci(&buf[idx], &idx);		/* type_name */
+	if (hdr->file_version > 61) idx += 4;	/* skip export size */
+	*objsize = get_fci(&buf[idx], &idx);
+	*ofs += idx;	/* offset for real data */
+
+	return t;	/* return type_name index */
+}
+
+static int read_typname(fshandle_t *f, const struct upkg_hdr *hdr,
+			int idx, char *out)
+{
+	int i, s;
+	long l;
+	char buf[64];
+
+	if (idx >= hdr->name_count) return -1;
+	buf[63] = '\0';
+	for (i = 0, l = 0; i <= idx; i++) {
+		FS_fseek(f, hdr->name_offset + l, SEEK_SET);
+		FS_fread(buf, 1, 63, f);
+		if (hdr->file_version >= 64) {
+			s = *(signed char *)buf; /* numchars *including* terminator */
+			if (s <= 0 || s > 64) return -1;
+			l += s + 5;	/* 1 for buf[0], 4 for int32_t name_flags */
+		} else {
+			l += (long)strlen(buf);
+			l +=  5;	/* 1 for terminator, 4 for int32_t name_flags */
+		}
+	}
+
+	strcpy(out, (hdr->file_version >= 64)? &buf[1] : buf);
+	return 0;
+}
+
+static int probe_umx   (fshandle_t *f, const struct upkg_hdr *hdr,
+			int32_t *ofs, int32_t *objsize)
+{
+	int i, idx, t;
+	int32_t s, pos;
+	long fsiz;
+	char buf[64];
+
+	idx = 0;
+	fsiz = FS_filelength (f);
+
+	/* Find the offset and size of the first IT, S3M or XM
+	 * by parsing the exports table. The umx files should
+	 * have only one export. Kran32.umx from Unreal has two,
+	 * but both pointing to the same music. */
+	if (hdr->export_offset >= fsiz) return -1;
+	memset(buf, 0, 64);
+	FS_fseek(f, hdr->export_offset, SEEK_SET);
+	FS_fread(buf, 1, 64, f);
+
+	get_fci(&buf[idx], &idx);	/* skip class_index */
+	get_fci(&buf[idx], &idx);	/* skip super_index */
+	if (hdr->file_version >= 60) idx += 4; /* skip int32 package_index */
+	get_fci(&buf[idx], &idx);	/* skip object_name */
+	idx += 4;			/* skip int32 object_flags */
+
+	s = get_fci(&buf[idx], &idx);	/* get serial_size */
+	if (s <= 0) return -1;
+	pos = get_fci(&buf[idx],&idx);	/* get serial_offset */
+	if (pos < 0 || pos > fsiz - 40) return -1;
+
+	if ((t = read_export(f, hdr, &pos, &s)) < 0) return -1;
+	if (s <= 0 || s > fsiz - pos) return -1;
+
+	if (read_typname(f, hdr, t, buf) < 0) return -1;
+	for (i = 0; mustype[i] != NULL; i++) {
+		if (!q_strcasecmp(buf, mustype[i])) {
+			t = i;
+			break;
+		}
+	}
+	if (mustype[i] == NULL) return -1;
+	if ((t = get_objtype(f, pos, t)) < 0) return -1;
+
+	*ofs = pos;
+	*objsize = s;
+	return t;
+}
+
+static int32_t probe_header (void *header)
+{
+	struct upkg_hdr *hdr;
+	unsigned char *p;
+	uint32_t *swp;
+	int i;
+
+	/* byte swap the header - all members are 32 bit LE values */
+	p = (unsigned char *) header;
+	swp = (uint32_t *) header;
+	for (i = 0; i < UPKG_HDR_SIZE/4; i++, p += 4) {
+		swp[i] = p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
+	}
+
+	hdr = (struct upkg_hdr *) header;
+	if (hdr->tag != UPKG_HDR_TAG) {
+		Con_DPrintf("Unknown header tag 0x%x\n", hdr->tag);
+		return -1;
+	}
+	if (hdr->name_count	< 0	||
+	    hdr->name_offset	< 0	||
+	    hdr->export_count	< 0	||
+	    hdr->export_offset	< 0	||
+	    hdr->import_count	< 0	||
+	    hdr->import_offset	< 0	) {
+		Con_DPrintf("Negative values in header\n");
+		return -1;
+	}
+
+	switch (hdr->file_version) {
+	case 35: case 37:	/* Unreal beta - */
+	case 40: case 41:				/* 1998 */
+	case 61:/* Unreal */
+	case 62:/* Unreal Tournament */
+	case 63:/* Return to NaPali */
+	case 64:/* Unreal Tournament */
+	case 66:/* Unreal Tournament */
+	case 68:/* Unreal Tournament */
+	case 69:/* Tactical Ops */
+	case 75:/* Harry Potter and the Philosopher's Stone */
+	case 76:			/* mpeg layer II data */
+	case 83:/* Mobile Forces */
+		return 0;
+	}
+
+	Con_DPrintf("Unknown upkg version %d\n", hdr->file_version);
+	return -1;
+}
+
+static int process_upkg (fshandle_t *f, int32_t *ofs, int32_t *objsize)
+{
+	char header[UPKG_HDR_SIZE];
+
+	if (FS_fread(header, 1, UPKG_HDR_SIZE, f) < UPKG_HDR_SIZE)
+		return -1;
+	if (probe_header(header) < 0)
+		return -1;
+
+	return probe_umx(f, (struct upkg_hdr *)header, ofs, objsize);
+}
+
+static qboolean S_UMX_CodecInitialize (void)
+{
+	return true;
+}
+
+static void S_UMX_CodecShutdown (void)
+{
+}
+
+static qboolean S_UMX_CodecOpenStream (snd_stream_t *stream)
+{
+	int type;
+	int32_t ofs = 0, size = 0;
+
+	type = process_upkg(&stream->fh, &ofs, &size);
+	if (type < 0) {
+		Con_DPrintf("%s: unrecognized umx\n", stream->name);
+		return false;
+	}
+
+	Con_DPrintf("%s: %s data @ 0x%x, %d bytes\n", stream->name, mustype[type], ofs, size);
+	/* hack the fshandle_t start pos and length members so
+	 * that only the relevant data is accessed from now on */
+	stream->fh.start += ofs;
+	stream->fh.length = size;
+	FS_fseek(&stream->fh, 0, SEEK_SET);
+
+	switch (type) {
+	case UMUSIC_IT:
+	case UMUSIC_S3M:
+	case UMUSIC_XM:
+	case UMUSIC_MOD: return S_CodecForwardStream(stream, CODECTYPE_MOD);
+	case UMUSIC_WAV: return S_CodecForwardStream(stream, CODECTYPE_WAV);
+	case UMUSIC_MP2: return S_CodecForwardStream(stream, CODECTYPE_MP3);
+	}
+
+	return false;
+}
+
+static int S_UMX_CodecReadStream (snd_stream_t *stream, int bytes, void *buffer)
+{
+	return -1;
+}
+
+static void S_UMX_CodecCloseStream (snd_stream_t *stream)
+{
+	S_CodecUtilClose(&stream);
+}
+
+static int S_UMX_CodecRewindStream (snd_stream_t *stream)
+{
+	return -1;
+}
+
+snd_codec_t umx_codec =
+{
+	CODECTYPE_UMX,
+	true,	/* always available. */
+	"umx",
+	S_UMX_CodecInitialize,
+	S_UMX_CodecShutdown,
+	S_UMX_CodecOpenStream,
+	S_UMX_CodecReadStream,
+	S_UMX_CodecRewindStream,
+	S_UMX_CodecCloseStream,
+	NULL
+};
+
+#endif	/* USE_CODEC_UMX */
+

--- a/common/snd_umx.h
+++ b/common/snd_umx.h
@@ -1,0 +1,12 @@
+/* Unreal UMX format support */
+#if !defined(_SND_UMX_H_)
+#define _SND_UMX_H_
+
+#if defined(USE_CODEC_UMX)
+
+extern snd_codec_t umx_codec;
+
+#endif	/* USE_CODEC_UMX */
+
+#endif	/* ! _SND_UMX_H_ */
+

--- a/common/snd_vorbis.c
+++ b/common/snd_vorbis.c
@@ -1,0 +1,210 @@
+/*
+ * Ogg/Vorbis streaming music support, loosely based on several open source
+ * Quake engine based projects with many modifications.
+ *
+ * Copyright (C) 2010-2012 O.Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "quakedef.h"
+#include "sound.h"
+#include "console.h"
+#include "common.h"
+
+
+#if defined(USE_CODEC_VORBIS)
+#include "snd_codec.h"
+#include "snd_codeci.h"
+#include "snd_vorbis.h"
+
+#define OV_EXCLUDE_STATIC_CALLBACKS
+#if defined(VORBIS_USE_TREMOR)
+/* for Tremor / Vorbisfile api differences,
+ * see doc/diff.html in the Tremor package. */
+#include <tremor/ivorbisfile.h>
+#else
+#include <vorbis/vorbisfile.h>
+#endif
+
+/* Vorbis codec can return the samples in a number of different
+ * formats, we use the standard signed short format. */
+#define VORBIS_SAMPLEBITS 16
+#define VORBIS_SAMPLEWIDTH 2
+#define VORBIS_SIGNED_DATA 1
+
+/* CALLBACK FUNCTIONS: */
+
+static int ovc_fclose (void *f)
+{
+	return 0;		/* we fclose() elsewhere. */
+}
+
+static int ovc_fseek (void *f, ogg_int64_t off, int whence)
+{
+	if (f == NULL) return (-1);
+	return FS_fseek((fshandle_t *)f, (long) off, whence);
+}
+
+static ov_callbacks ovc_qfs =
+{
+	(size_t (*)(void *, size_t, size_t, void *))	FS_fread,
+	(int (*)(void *, ogg_int64_t, int))		ovc_fseek,
+	(int (*)(void *))				ovc_fclose,
+	(long (*)(void *))				FS_ftell
+};
+
+#define OV_OPEN_CALLBACKS		ov_open_callbacks
+
+static qboolean S_VORBIS_CodecInitialize (void)
+{
+	return true;
+}
+
+static void S_VORBIS_CodecShutdown (void)
+{
+}
+
+static qboolean S_VORBIS_CodecOpenStream (snd_stream_t *stream)
+{
+	OggVorbis_File *ovFile;
+	vorbis_info *ovf_info;
+	long numstreams;
+	int res;
+
+	ovFile = (OggVorbis_File *) Z_Malloc(sizeof(OggVorbis_File));
+	stream->priv = ovFile;
+	res = OV_OPEN_CALLBACKS(&stream->fh, ovFile, NULL, 0, ovc_qfs);
+	if (res != 0)
+	{
+		Con_Printf("%s is not a valid Ogg Vorbis file (error %i).\n",
+				stream->name, res);
+		goto _fail;
+	}
+
+	if (!ov_seekable(ovFile))
+	{
+		Con_Printf("Stream %s not seekable.\n", stream->name);
+		goto _fail;
+	}
+
+	ovf_info = ov_info(ovFile, 0);
+	if (!ovf_info)
+	{
+		Con_Printf("Unable to get stream info for %s.\n", stream->name);
+		goto _fail;
+	}
+
+	/* FIXME: handle section changes */
+	numstreams = ov_streams(ovFile);
+	if (numstreams != 1)
+	{
+		Con_Printf("More than one (%ld) stream in %s.\n",
+					numstreams, stream->name);
+		goto _fail;
+	}
+
+	if (ovf_info->channels != 1 && ovf_info->channels != 2)
+	{
+		Con_Printf("Unsupported number of channels %d in %s\n",
+					ovf_info->channels, stream->name);
+		goto _fail;
+	}
+
+	stream->info.rate = ovf_info->rate;
+	stream->info.channels = ovf_info->channels;
+	stream->info.bits = VORBIS_SAMPLEBITS;
+	stream->info.width = VORBIS_SAMPLEWIDTH;
+
+	return true;
+_fail:
+	if (res == 0)
+		ov_clear(ovFile);
+	Z_Free(ovFile);
+	return false;
+}
+
+static int S_VORBIS_CodecReadStream (snd_stream_t *stream, int bytes, void *buffer)
+{
+	int	section;	/* FIXME: handle section changes */
+	int	cnt, res, rem;
+	char *	ptr;
+
+	cnt = 0; rem = bytes;
+	ptr = (char *) buffer;
+	while (1)
+	{
+	/* # ov_read() from libvorbisfile returns the decoded PCM audio
+	 *   in requested endianness, signedness and word size.
+	 * # ov_read() from Tremor (libvorbisidec) returns decoded audio
+	 *   always in host-endian, signed 16 bit PCM format.
+	 * # For both of the libraries, if the audio is multichannel,
+	 *   the channels are interleaved in the output buffer.
+	 */
+		res = ov_read( (OggVorbis_File *)stream->priv, ptr, rem,
+#if !defined(VORBIS_USE_TREMOR)
+				bigendien,
+				VORBIS_SAMPLEWIDTH,
+				VORBIS_SIGNED_DATA,
+#endif	/* ! VORBIS_USE_TREMOR */
+				&section );
+		if (res <= 0)
+			break;
+		rem -= res;
+		cnt += res;
+		if (rem <= 0)
+			break;
+		ptr += res;
+	}
+
+	if (res < 0)
+		return res;
+	return cnt;
+}
+
+static void S_VORBIS_CodecCloseStream (snd_stream_t *stream)
+{
+	ov_clear((OggVorbis_File *)stream->priv);
+	Z_Free(stream->priv);
+	S_CodecUtilClose(&stream);
+}
+
+static int S_VORBIS_CodecRewindStream (snd_stream_t *stream)
+{
+/* for libvorbisfile, the ov_time_seek() position argument
+ * is seconds as doubles, whereas for Tremor libvorbisidec
+ * it is milliseconds as 64 bit integers.
+ */
+	return ov_time_seek ((OggVorbis_File *)stream->priv, 0);
+}
+
+snd_codec_t vorbis_codec =
+{
+	CODECTYPE_VORBIS,
+	true,	/* always available. */
+	"ogg",
+	S_VORBIS_CodecInitialize,
+	S_VORBIS_CodecShutdown,
+	S_VORBIS_CodecOpenStream,
+	S_VORBIS_CodecReadStream,
+	S_VORBIS_CodecRewindStream,
+	S_VORBIS_CodecCloseStream,
+	NULL
+};
+
+#endif	/* USE_CODEC_VORBIS */
+

--- a/common/snd_vorbis.h
+++ b/common/snd_vorbis.h
@@ -1,0 +1,13 @@
+/* Ogg/Vorbis streaming music support. */
+
+#if !defined(_SND_VORBIS_H_)
+#define _SND_VORBIS_H_ 1
+
+#if defined(USE_CODEC_VORBIS)
+
+extern snd_codec_t vorbis_codec;
+
+#endif	/* USE_CODEC_VORBIS */
+
+#endif	/* ! _SND_VORBIS_H_ */
+

--- a/common/snd_wave.c
+++ b/common/snd_wave.c
@@ -1,0 +1,278 @@
+/*
+ * WAV streaming music support. Adapted from ioquake3 with changes.
+ *
+ * Copyright (C) 1999-2005 Id Software, Inc.
+ * Copyright (C) 2005 Stuart Dalton <badcdev@gmail.com>
+ * Copyright (C) 2010-2012 O.Sezer <sezero@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "quakedef.h"
+#include "sound.h"
+#include "console.h"
+
+#if defined(USE_CODEC_WAVE)
+#include "snd_codec.h"
+#include "snd_codeci.h"
+#include "snd_wave.h"
+
+/*
+=================
+FGetLittleLong
+=================
+*/
+static int FGetLittleLong (FILE *f)
+{
+	int		v;
+
+	fread(&v, 1, sizeof(v), f);
+
+	return LittleLong(v);
+}
+
+/*
+=================
+FGetLittleShort
+=================
+*/
+static short FGetLittleShort(FILE *f)
+{
+	short	v;
+
+	fread(&v, 1, sizeof(v), f);
+
+	return LittleShort(v);
+}
+
+/*
+=================
+WAV_ReadChunkInfo
+=================
+*/
+static int WAV_ReadChunkInfo(FILE *f, char *name)
+{
+	int len, r;
+
+	name[4] = 0;
+
+	r = fread(name, 1, 4, f);
+	if (r != 4)
+		return -1;
+
+	len = FGetLittleLong(f);
+	if (len < 0)
+	{
+		Con_Printf("WAV: Negative chunk length\n");
+		return -1;
+	}
+
+	return len;
+}
+
+/*
+=================
+WAV_FindRIFFChunk
+
+Returns the length of the data in the chunk, or -1 if not found
+=================
+*/
+static int WAV_FindRIFFChunk(FILE *f, const char *chunk)
+{
+	char	name[5];
+	int		len;
+
+	while ((len = WAV_ReadChunkInfo(f, name)) >= 0)
+	{
+		/* If this is the right chunk, return */
+		if (!strncmp(name, chunk, 4))
+			return len;
+		len = ((len + 1) & ~1);	/* pad by 2 . */
+
+		/* Not the right chunk - skip it */
+		fseek(f, len, SEEK_CUR);
+	}
+
+	return -1;
+}
+
+/*
+=================
+WAV_ReadRIFFHeader
+=================
+*/
+static qboolean WAV_ReadRIFFHeader(const char *name, FILE *file, snd_info_t *info)
+{
+	char dump[16];
+	int wav_format;
+	int fmtlen = 0;
+
+	if (fread(dump, 1, 12, file) < 12 ||
+	    strncmp(dump, "RIFF", 4) != 0 ||
+	    strncmp(&dump[8], "WAVE", 4) != 0)
+	{
+		Con_Printf("%s is missing RIFF/WAVE chunks\n", name);
+		return false;
+	}
+
+	/* Scan for the format chunk */
+	if ((fmtlen = WAV_FindRIFFChunk(file, "fmt ")) < 0)
+	{
+		Con_Printf("%s is missing fmt chunk\n", name);
+		return false;
+	}
+
+	/* Save the parameters */
+	wav_format = FGetLittleShort(file);
+	if (wav_format != WAV_FORMAT_PCM)
+	{
+		Con_Printf("%s is not Microsoft PCM format\n", name);
+		return false;
+	}
+
+	info->channels = FGetLittleShort(file);
+	info->rate = FGetLittleLong(file);
+	FGetLittleLong(file);
+	FGetLittleShort(file);
+	info->bits = FGetLittleShort(file);
+
+	if (info->bits != 8 && info->bits != 16)
+	{
+		Con_Printf("%s is not 8 or 16 bit\n", name);
+		return false;
+	}
+
+	info->width = info->bits / 8;
+	info->dataofs = 0;
+
+	/* Skip the rest of the format chunk if required */
+	if (fmtlen > 16)
+	{
+		fmtlen -= 16;
+		fseek(file, fmtlen, SEEK_CUR);
+	}
+
+	/* Scan for the data chunk */
+	if ((info->size = WAV_FindRIFFChunk(file, "data")) < 0)
+	{
+		Con_Printf("%s is missing data chunk\n", name);
+		return false;
+	}
+
+	if (info->channels != 1 && info->channels != 2)
+	{
+		Con_Printf("Unsupported number of channels %d in %s\n",
+						info->channels, name);
+		return false;
+	}
+	info->samples = (info->size / info->width) / info->channels;
+	if (info->samples == 0)
+	{
+		Con_Printf("%s has zero samples\n", name);
+		return false;
+	}
+
+	return true;
+}
+
+/*
+=================
+S_WAV_CodecOpenStream
+=================
+*/
+static qboolean S_WAV_CodecOpenStream(snd_stream_t *stream)
+{
+	long start = stream->fh.start;
+
+	/* Read the RIFF header */
+	/* The file reads are sequential, therefore no need
+	 * for the FS_*() functions: We will manipulate the
+	 * file by ourselves from now on. */
+	if (!WAV_ReadRIFFHeader(stream->name, stream->fh.file, &stream->info))
+		return false;
+
+	stream->fh.start = ftell(stream->fh.file); /* reset to data position */
+	if (stream->fh.start - start + stream->info.size > stream->fh.length)
+	{
+		Con_Printf("%s data size mismatch\n", stream->name);
+		return false;
+	}
+
+	return true;
+}
+
+/*
+=================
+S_WAV_CodecReadStream
+=================
+*/
+int S_WAV_CodecReadStream(snd_stream_t *stream, int bytes, void *buffer)
+{
+	int remaining = stream->info.size - stream->fh.pos;
+	int i, samples;
+
+	if (remaining <= 0)
+		return 0;
+	if (bytes > remaining)
+		bytes = remaining;
+	stream->fh.pos += bytes;
+	fread(buffer, 1, bytes, stream->fh.file);
+	if (stream->info.width == 2)
+	{
+		samples = bytes / 2;
+		for (i = 0; i < samples; i++)
+			((short *)buffer)[i] = LittleShort( ((short *)buffer)[i] );
+	}
+	return bytes;
+}
+
+static void S_WAV_CodecCloseStream (snd_stream_t *stream)
+{
+	S_CodecUtilClose(&stream);
+}
+
+static int S_WAV_CodecRewindStream (snd_stream_t *stream)
+{
+	FS_rewind(&stream->fh);
+	return 0;
+}
+
+static qboolean S_WAV_CodecInitialize (void)
+{
+	return true;
+}
+
+static void S_WAV_CodecShutdown (void)
+{
+}
+
+snd_codec_t wav_codec =
+{
+	CODECTYPE_WAVE,
+	true,	/* always available. */
+	"wav",
+	S_WAV_CodecInitialize,
+	S_WAV_CodecShutdown,
+	S_WAV_CodecOpenStream,
+	S_WAV_CodecReadStream,
+	S_WAV_CodecRewindStream,
+	S_WAV_CodecCloseStream,
+	NULL
+};
+
+#endif	/* USE_CODEC_WAVE */
+

--- a/common/snd_wave.h
+++ b/common/snd_wave.h
@@ -1,0 +1,13 @@
+/* WAV streaming music support. */
+
+#if !defined(_SND_WAVE_H_)
+#define _SND_WAVE_H_
+
+#if defined(USE_CODEC_WAVE)
+
+extern snd_codec_t wav_codec;
+
+#endif	/* USE_CODEC_WAVE */
+
+#endif	/* ! _SND_WAVE_H_ */
+

--- a/common/sound.h
+++ b/common/sound.h
@@ -88,6 +88,18 @@ typedef struct {
     int master_vol;		// 0-255 master volume
 } channel_t;
 
+#define WAV_FORMAT_PCM	1
+
+typedef struct
+{
+	int	rate;
+	int	width;
+	int	channels;
+	int	loopstart;
+	int	samples;
+	int	dataofs;		/* chunk starts this many bytes from file start	*/
+} wavinfo_t;
+
 void S_Init(void);
 void S_Startup(void);
 void S_Shutdown(void);
@@ -137,7 +149,7 @@ extern int total_channels;
 
 extern int paintedtime;
 extern volatile dma_t *shm;
-extern volatile dma_t sn;
+extern int s_rawend;
 
 extern cvar_t loadas8bit;
 extern cvar_t bgmvolume;
@@ -145,11 +157,15 @@ extern cvar_t sfxvolume;
 
 extern int snd_blocked;
 
+#define	MAX_RAW_SAMPLES	8192
+extern	portable_samplepair_t	s_rawsamples[MAX_RAW_SAMPLES];
+
 void S_LocalSound(const char *s);
 sfxcache_t *S_LoadSound(sfx_t *s);
 
 void SND_InitScaletable(void);
 void SNDDMA_Submit(void);
+wavinfo_t *GetWavinfo (const char *name, byte *wav, int wavlength);
 
 void S_AmbientOff(void);
 void S_AmbientOn(void);

--- a/common/sound.h
+++ b/common/sound.h
@@ -119,6 +119,10 @@ void S_EndPrecaching(void);
 void S_PaintChannels(int endtime);
 void S_InitPaintChannels(void);
 
+/* music stream support */
+void S_RawSamples(int samples, int rate, int width, int channels, byte * data, float volume);
+				/* Expects data in signed 16 bit, or unsigned 8 bit format. */
+
 // initializes cycling through a DMA buffer and returns information on it
 qboolean SNDDMA_Init(dma_t *dma);
 

--- a/common/sound.h
+++ b/common/sound.h
@@ -68,6 +68,7 @@ typedef struct {
     int submission_chunk;	// don't mix less than this #
     int samplepos;		// in mono samples
     int samplebits;
+	int	signed8;		/* device opened for S8 format? (e.g. Amiga AHI) */
     int speed;
     unsigned char *buffer;
 } dma_t;
@@ -107,7 +108,7 @@ void S_PaintChannels(int endtime);
 void S_InitPaintChannels(void);
 
 // initializes cycling through a DMA buffer and returns information on it
-qboolean SNDDMA_Init(void);
+qboolean SNDDMA_Init(dma_t *dma);
 
 // gets the current DMA position
 int SNDDMA_GetDMAPos(void);
@@ -140,7 +141,7 @@ extern volatile dma_t sn;
 
 extern cvar_t loadas8bit;
 extern cvar_t bgmvolume;
-extern cvar_t volume;
+extern cvar_t sfxvolume;
 
 extern int snd_blocked;
 


### PR DESCRIPTION
Imports quakespasm ability to play the bgm from audio files rather than audio CDs as described in [here](http://quakespasm.sourceforge.net/Quakespasm.html#ss3.1).

I've reworked this patchset to bring as little as possible from quakespasm sound system. I wanted to preserve tyrquake/vanilla quake sound "quality", so this new approach avoided the clean sound from quakespasm.

This bgm system supports multiple audio codecs but i've left only flac, wave and vorbis enabled for now.