### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ DEBUG=0
 FRONTEND_SUPPORTS_RGB565=1
 TARGET_NAME=tyrquake
 STATIC_LINKING=0
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 ifeq ($(platform),)
 platform = unix

--- a/common/libretro.c
+++ b/common/libretro.c
@@ -316,7 +316,10 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    memset(info, 0, sizeof(*info));
    info->library_name     = "TyrQuake";
-   info->library_version  = "v" stringify(TYR_VERSION);
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version  = "v" stringify(TYR_VERSION) GIT_VERSION;
    info->need_fullpath    = true;
    info->valid_extensions = "pak";
 }

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,4 +1,8 @@
 LOCAL_PATH := $(call my-dir)
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 include $(CLEAR_VARS)
 


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.