### PR TITLE
Fixes a crash in the game when playing a level such as r1m3 in Quake …

### DIFF
--- a/common/world.c
+++ b/common/world.c
@@ -191,8 +191,6 @@ static hull_t *SV_HullForEntity(edict_t *ent, vec3_t mins, vec3_t maxs, vec3_t o
             hull = &model->hulls[0];
          else if ((size[0] <= 8)&&((int)(sv.edicts->v.spawnflags)&1))  /* Pentacles */
             hull = &model->hulls[4];
-         else if (size[0] <= 32 && size[2] <= 28)  /* Half Player */
-            hull = &model->hulls[3];
          else if (size[0] <= 32)
             hull = &model->hulls[1];
          else


### PR DESCRIPTION
…Mission Pack 2

This removes half player hull in SV_HullForEntity() from commit 0393e7b5da3e54f95b199ca789d4d6f3930e5745

I'm not sure if the half player hull was meant to go with the hexen2 ifdef, so i just reverted it.
I suspected a monster was generating such a hull, but while debugging all I could see was that the world entity was causing the crash wile tracing the hull.