### PR TITLE
Fix crash due to array access out of bounds

### DIFF
--- a/common/libretro.c
+++ b/common/libretro.c
@@ -740,7 +740,7 @@ static void update_variables(bool startup)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
    {
       unsigned i;
-      for (i=0; gp_layouts[i].name; ++i)
+      for (i=0; i < sizeof(gp_layouts)/sizeof(gp_layout_t); ++i)
       {
          if (strcmp(var.value, gp_layouts[i].name) == 0)
          {


### PR DESCRIPTION
On Raspberry Pi 3, lr-tyrquake core crashes with "Illegal instruction" error. Problem was traced to commit https://github.com/libretro/tyrquake/commit/2b0c9f232a9505862f10abc45558c0703a9d30b8

Debugging the issue led to the discovery of gp_layouts[2].name erroneously returning the contents of the "layouts" string.