### PR TITLE
Add 'Smooth Movement' to in-game video options menu

### DIFF
--- a/common/menu.c
+++ b/common/menu.c
@@ -1073,7 +1073,7 @@ M_OptionsInput_Key(int k)
 //=============================================================================
 /* VIDEO OPTIONS MENU */
 
-#define	OPTIONSVIDEO_ITEMS 8
+#define	OPTIONSVIDEO_ITEMS 9
 
 static int optionsvideo_cursor;
 
@@ -1128,6 +1128,10 @@ M_OptionsVideo_AdjustSliders(int dir)
        Cvar_SetValue("r_lerpmodels", cvar->value ? 0.0f : 1.0f);
        break;
    case 7:
+       cvar = Cvar_FindVar("r_lerpmove");
+       Cvar_SetValue("r_lerpmove", cvar->value ? 0.0f : 1.0f);
+       break;
+   case 8:
        cvar = Cvar_FindVar("framerate");
        Cvar_SetValue("framerate", (cvar->value == 60) ? 50.0f : 60.0f);
        break;
@@ -1173,13 +1177,17 @@ M_OptionsVideo_Draw(void)
     cvar = Cvar_FindVar("r_lerpmodels");
     M_Print(16, 80, "      Smooth Animation");
     M_DrawCheckbox(220, 80, cvar->value);
+    
+    cvar = Cvar_FindVar("r_lerpmove");
+    M_Print(16, 88, "      Smooth Movement");
+    M_DrawCheckbox(220, 88, cvar->value);
 
     cvar = Cvar_FindVar("framerate");
-    M_Print(16,88, "      Framerate");
+    M_Print(16,96, "      Framerate");
     if (cvar->value == 60)
-       M_Print(220,88, "60fps");
+       M_Print(220,96, "60fps");
     else
-       M_Print(220,88,"50fps");
+       M_Print(220,96,"50fps");
 
 // cursor
     M_DrawCharacter(200, 32 + optionsvideo_cursor * 8,


### PR DESCRIPTION
The existing core has the in-game video option 'Smooth Animation', which enables/disables linear interpolation for character animations (it sets 'r_lerpmodels' to 1 or 0). It doesn't, however, enable/disable linear interpolation for character *movement* - this is set by a different cvar ('r_lerpmove').

The result is that you can turn 'Smooth Animation' on, and the enemies still jerk around in horrible fashion. It looks like they are 'teleporting' from step to step. Setting both 'r_lerpmodels' and 'r_lerpmove' to zero is fine if you want an authentic Quake experience, but if you set one of them to 1 then you should probably set the other to 1 as well...

This trivial pull request just adds an additional 'Smooth Movement' setting to the in-game video menu, so users can set 'r_lerpmove' to 1 without rooting around in config files.