### PR TITLE
Add analog deadzone to core options + remap useless controller button

### DIFF
--- a/common/libretro.c
+++ b/common/libretro.c
@@ -122,7 +122,7 @@ gp_layout_t modern = {
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "Next weapon" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "Jump" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "Fire" },
-      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,"Toggle console" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,"Show Scores" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Menu" },
       { 0 },
    },
@@ -133,7 +133,7 @@ gp_layout_t modern = {
       {"JOY_X",     "+moveup"},       {"JOY_Y",     "+moveleft"},
       {"JOY_L",     "impulse 12"},    {"JOY_R",     "impulse 10"},
       {"JOY_L2",    "+jump"},         {"JOY_R2",    "+attack"},
-      {"JOY_SELECT","toggleconsole"}, {"JOY_START", "togglemenu"},
+      {"JOY_SELECT","+showscores"},   {"JOY_START", "togglemenu"},
       { 0 },
    },
 };


### PR DESCRIPTION
This pull request allows the analog deadzone to be configured via the core options interface. This makes the core usable with old xbox 360 gamepads, which are notoriously prone to analog stick drift.

While I was adjusting the controls, I also took the opportunity to remap a useless button in the 'modern' controller layout...

Previously, 'select' was set to toggle the console. This had no real value, since to use the console in any meaningful fashion requires a keyboard - and if you have a keyboard, there are already 3 keys you can press to toggle the console. I have modified 'select' so that it now shows the current scores, so users can easily see how many monsters/secrets are remaining (I think this is far more useful in a gamepad-only/console-type environment).