### PR TITLE
Move core-generated files (config + saves) to frontend-defined save directory

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -2007,9 +2007,15 @@ static void COM_InitFilesystem(void)
    COM_AddGameDirectory(com_basedir, "qw");
 #endif
    
-   // Hack: add save directory to search path
-   // (otherwise 'exec config.cfg' will fail...)
-   COM_AddGameDirectory(com_savedir, "");
+   // Hack: Add save directory to search path, otherwise 'exec config.cfg' will fail
+   // (NB: 'host_parms.use_exernal_savedir' is a bit of a kludge, but since basedir
+   //  changes depending upon the game being loaded and various flags modify the
+   //  final 'rom' directory, it's the cleanest way to prevent the same directory
+   //  being added to the search list twice...)
+   if (host_parms.use_exernal_savedir != 0)
+   {
+		COM_AddGameDirectory(com_savedir, "");
+	}
    
    //
    // -path <dir or packfile> [<dir or packfile>] ...

--- a/common/common.c
+++ b/common/common.c
@@ -1264,6 +1264,7 @@ typedef struct
 
 char com_gamedir[MAX_OSPATH];
 char com_basedir[MAX_OSPATH];
+char com_savedir[MAX_OSPATH];
 
 typedef struct searchpath_s {
     char filename[MAX_OSPATH];
@@ -1974,6 +1975,9 @@ static void COM_InitFilesystem(void)
    searchpath_t *search;
 #endif
 
+   // Set save directory
+   strcpy(com_savedir, host_parms.savedir);
+   
    // -basedir <path>
    // Overrides the system supplied base directory (under id1)
    i = COM_CheckParm("-basedir");
@@ -2002,6 +2006,11 @@ static void COM_InitFilesystem(void)
 #ifdef QW_HACK
    COM_AddGameDirectory(com_basedir, "qw");
 #endif
+   
+   // Hack: add save directory to search path
+   // (otherwise 'exec config.cfg' will fail...)
+   COM_AddGameDirectory(com_savedir, "");
+   
    //
    // -path <dir or packfile> [<dir or packfile>] ...
    // Fully specifies the exact search path, overriding the generated one

--- a/common/common.h
+++ b/common/common.h
@@ -199,6 +199,7 @@ struct cache_user_s;
 
 extern char com_basedir[MAX_OSPATH];
 extern char com_gamedir[MAX_OSPATH];
+extern char com_savedir[MAX_OSPATH];
 extern int file_from_pak; // global indicating that file came from a pak
 
 void COM_WriteFile(const char *filename, const void *data, int len);

--- a/common/console.c
+++ b/common/console.c
@@ -322,7 +322,7 @@ void Con_Printf(const char *fmt, ...)
 
    /* log all messages to file */
    if (debuglog)
-      Sys_DebugLog(va("%s/qconsole.log", com_gamedir), "%s", msg);
+      Sys_DebugLog(va("%s/qconsole.log", com_savedir), "%s", msg);
 
    if (!con_initialized)
       return;
@@ -381,7 +381,7 @@ Con_DPrintf(const char *fmt, ...)
 	    va_start(argptr, fmt);
 	    vsnprintf(msg + 7, sizeof(msg) - 7, fmt, argptr);
 	    va_end(argptr);
-	    Sys_DebugLog(va("%s/qconsole.log", com_gamedir), "%s", msg);
+	    Sys_DebugLog(va("%s/qconsole.log", com_savedir), "%s", msg);
 	}
 	return;
     }

--- a/common/host.c
+++ b/common/host.c
@@ -271,7 +271,7 @@ Host_WriteConfiguration(void)
 // dedicated servers initialize the host but don't parse and set the
 // config.cfg cvars
     if (host_initialized & !isDedicated) {
-	f = fopen(va("%s/config.cfg", com_gamedir), "w");
+	f = fopen(va("%s/config.cfg", com_savedir), "w");
 	if (!f) {
 	    Con_Printf("Couldn't write config.cfg.\n");
 	    return;

--- a/common/host_cmd.c
+++ b/common/host_cmd.c
@@ -498,7 +498,7 @@ void Host_Savegame_f(void)
       }
    }
 
-   sprintf(name, "%s%c%s", com_gamedir, slash, Cmd_Argv(1));
+   sprintf(name, "%s%c%s", com_savedir, slash, Cmd_Argv(1));
    COM_DefaultExtension(name, ".sav");
 
    Con_Printf("Saving game to %s...\n", name);
@@ -572,7 +572,7 @@ void Host_Loadgame_f(void)
 
    cls.demonum = -1;		// stop demo loop in case this fails
 
-   sprintf(name, "%s%c%s", com_gamedir, slash, Cmd_Argv(1));
+   sprintf(name, "%s%c%s", com_savedir, slash, Cmd_Argv(1));
    COM_DefaultExtension(name, ".sav");
 
    // we can't call SCR_BeginLoadingPlaque, because too much stack space has

--- a/common/menu.c
+++ b/common/menu.c
@@ -500,7 +500,7 @@ static void M_ScanSaves(void)
 
       strcpy(m_filenames[i], "--- UNUSED SLOT ---");
       loadable[i] = false;
-      sprintf(name, "%s%cs%i.sav", com_gamedir, slash, i);
+      sprintf(name, "%s%cs%i.sav", com_savedir, slash, i);
       f = fopen(name, "r");
       if (!f)
          continue;

--- a/common/quakedef.h
+++ b/common/quakedef.h
@@ -204,6 +204,7 @@ typedef struct {
 
 typedef struct {
     const char *basedir;
+    const char *savedir;
     int argc;
     const char **argv;
     void *membase;

--- a/common/quakedef.h
+++ b/common/quakedef.h
@@ -205,6 +205,7 @@ typedef struct {
 typedef struct {
     const char *basedir;
     const char *savedir;
+    unsigned short use_exernal_savedir; // should be a bool, but don't want to mess with the headers...
     int argc;
     const char **argv;
     void *membase;


### PR DESCRIPTION
The existing core writes the Quake 'config.cfg' + save files to the actual game directory. This is *not good*, for the following reasons:

- It doesn't follow the RetroArch standard of writing save files to the frontend-defined save directory.

- It makes it a nuisance to backup/restore game saves. With other cores, all saves are in one place and can easily be archived and shared across different machines. With the current tyrquake core, one has to grub around in individual game directories and pick out specific files.

- It means the game data has to be kept on writeable storage. This is a significant problem on Android devices, where internal storage is limited and it is often desirable to place large roms on an 'external' micro SD card - which in many cases cannot be written to by user apps. (Every Android device I own has this problem...)

This pull request very simply modifies the core such that the 'config.cfg' + save files are written to an appropriate subdirectory (named after the game folder) inside the frontend-defined save directory. It makes things tidy, and the game data can be set read-only without issue.