### PR TITLE
iOS: support for building using buildbot recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,14 @@ else ifneq (,$(findstring ios,$(platform)))
 ifeq ($(IOSSDK),)
    IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
 endif
-
+ifeq ($(platform), ios-arm64)
+   CFLAGS += -DIOS_ARM64
+   CC = clang -arch arm64 -isysroot $(IOSSDK) -march=armv8-a -mtune=cortex-a57 -mtp=soft
+else
    CC = clang -arch armv7 -isysroot $(IOSSDK)
+endif
    CFLAGS += -DIOS
-ifeq ($(platform),ios9)
+ifeq ($(platform),$(filter $(platform),ios9 ios-arm64))
 	CC     += -miphoneos-version-min=8.0
 	CFLAGS += -miphoneos-version-min=8.0
 else

--- a/common/mathlib.c
+++ b/common/mathlib.c
@@ -355,7 +355,7 @@ void _VectorCopy(vec3_t in, vec3_t out)
 
 void CrossProduct(const vec3_t v1, const vec3_t v2, vec3_t cross)
 {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) && !defined(IOS_ARM64)
    asm volatile (
          "flds s3, [%0] \n\t" //d1[1]={x0}
          "add %0, %0, #4 \n\t" //


### PR DESCRIPTION
add flag for ios-arm64 since it does not have neon instructions