### PR TITLE
Add Raspberry Pi 4 64bit platform.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,15 @@ else ifeq ($(platform), rpi3_64)
         CFLAGS += -march=armv8-a+crc -mtune=cortex-a53
         CFLAGS += -fomit-frame-pointer
 
+# Raspberry Pi 4 with 64bit kernel & libs
+else ifeq ($(platform), rpi4_64)
+        TARGET := $(TARGET_NAME)_libretro.so
+        fpic := -fPIC
+        SHARED := -shared -Wl,--version-script=common/libretro-link.T
+        CFLAGS += -DARM
+        CFLAGS += -march=armv8-a+crc+simd -mtune=cortex-a72
+        CFLAGS += -fomit-frame-pointer
+
 # Classic Platforms ####################
 # Platform affix = classic_<ISA>_<µARCH>
 # Help at https://modmyclassic.com/comp


### PR DESCRIPTION
Adds support for easily building for Raspberry Pi 4 in 64bit mode. There is already a Raspberry Pi OS BETA (formerly Raspbian) with 64bit kernel and libs, and that's what the Pi4 will use as default at some point. 