### PR TITLE
Allow high framerate.

### DIFF
--- a/common/host.c
+++ b/common/host.c
@@ -513,8 +513,10 @@ Host_FilterTime(float time)
 {
     realtime += time;
 
+    /* allow high framerate, warn about it in core options
     if (!cls.timedemo && realtime - oldrealtime < 1.0 / 72.0)
 	return false;		// framerate is too high
+    */
 
     host_frametime = realtime - oldrealtime;
     oldrealtime = realtime;

--- a/common/libretro_core_options.h
+++ b/common/libretro_core_options.h
@@ -77,7 +77,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "tyrquake_framerate",
       "Framerate (restart)",
-      "Modify framerate. Requires a restart.",
+      "Modify framerate. Requires a restart. Values above 72 may cause various timing bugs.",
       {
          { "auto",            "Auto"},
          { "10",              "10fps"},


### PR DESCRIPTION
Allow high framerate, warn about it in core options.

Didn't see much problems with 120fps playing several levels, even with traps in them.