### PR TITLE
WIIU: fix the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,7 +386,7 @@ else ifeq ($(platform), wiiu)
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
    CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-   CFLAGS += -DGEKKO -DHW_RVL -DWIIU -mwup -mcpu=750 -meabi -mhard-float -D__ppc__ -DMSB_FIRST -I$(DEVKITPRO)/libogc/include
+   CFLAGS += -DWIIU -mwup -mcpu=750 -meabi -mhard-float -D__ppc__ -DMSB_FIRST -I$(DEVKITPRO)/libogc/include
    CFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
 	STATIC_LINKING = 1
 	HAVE_NETWORKING=0

--- a/common/libretro.c
+++ b/common/libretro.c
@@ -21,7 +21,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "libretro.h"
 #include "libretro_core_options.h"
 #include <retro_miscellaneous.h>
-#include <retro_timers.h>
 #include <file/file_path.h>
 
 #if defined(_WIN32) && !defined(_XBOX)
@@ -747,11 +746,6 @@ static void keyboard_cb(bool down, unsigned keycode,
       else
          Key_Event((knum_t) keycode, 0);
    }
-}
-
-void Sys_Sleep(void)
-{
-   retro_sleep(1);
 }
 
 const char *argv[MAX_NUM_ARGVS];

--- a/common/sys.h
+++ b/common/sys.h
@@ -65,8 +65,6 @@ double Sys_DoubleTime(void);
 
 char *Sys_ConsoleInput(void);
 
-void Sys_Sleep(void);
-
 // called to yield for a little bit so as
 // not to hog cpu when paused or debugging
 


### PR DESCRIPTION
== DETAILS
The build is broken for a couple of reasons:

1. The wiiu target sets flags for GameCube/Wii that should not be set
2. Even though `retro_sleep()` isn't actually called, its include is
   still present and that causes the build to fail on wiiu

The `retro_sleep` compile failure is kinda its own issue, but in this
case we can sidestep it. The proper fix for this would be to update
this core so it doesn't keep its own copy of libretro-common, but that's
more work than I have time to complete.

Change summary:

1. remove the GC/Wii flags so we don't try to include libogc headers
2. remove `retro_sleep()` and go a little further and remove the
   `Sys_Sleep()` function that isn't actually called anywhere.

I have confirmed that it builds. I have not confirmed that it works.