### PR TITLE
Improve type safety when casting pointers

### DIFF
--- a/common/alias_model.c
+++ b/common/alias_model.c
@@ -45,7 +45,7 @@ static int posenum;
 // a skin may be an animating set 1 or more textures
 static float skinintervals[MAXALIASSKINS];
 static byte *skindata[MAXALIASSKINS];
-static int skinnum;
+static uintptr_t skinnum;
 
 /*
 =================
@@ -137,7 +137,7 @@ Mod_LoadAliasSkinGroup(void *pin, maliasskindesc_t *pskindesc, int skinsize)
 
    daliasskingroup_t *pinskingroup  = (daliasskingroup_t*)pin;
 
-   pskindesc->firstframe = (int)((daliasskingroup_t*)skinnum);
+   pskindesc->firstframe = (uintptr_t)((daliasskingroup_t*)skinnum);
 #ifdef MSB_FIRST
    pskindesc->numframes = LittleLong(pinskingroup->numskins);
 #else

--- a/common/d_fill.c
+++ b/common/d_fill.c
@@ -19,6 +19,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 // d_clear: clears a specified rectangle to the specified color
 
+#include <stdint.h>
+
 #include "quakedef.h"
 #include "vid.h"
 
@@ -56,10 +58,10 @@ void D_FillRect(vrect_t *rect, int color)
 
    dest = ((byte *)vid.buffer + ry * vid.rowbytes + rx);
 
-   if (((rwidth & 0x03) == 0) && (((long)dest & 0x03) == 0))
+   if (((rwidth & 0x03) == 0) && (((int32_t)dest & 0x03) == 0))
    {
       // faster aligned dword clear
-      unsigned *ldest = (unsigned *)dest;
+      uint32_t *ldest = (uint32_t *)dest;
       color += color << 16;
 
       rwidth >>= 2;
@@ -69,7 +71,7 @@ void D_FillRect(vrect_t *rect, int color)
       {
          for (rx = 0; rx < rwidth; rx++)
             ldest[rx] = color;
-         ldest = (unsigned *)((byte *)ldest + vid.rowbytes);
+         ldest = (uint32_t *)((byte *)ldest + vid.rowbytes);
       }
    }
    else

--- a/common/d_polyse.c
+++ b/common/d_polyse.c
@@ -20,6 +20,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // d_polyset.c: routines for drawing sets of polygons sharing the same
 // texture (used for Alias models)
 
+#include <stdint.h>
+
 #include "quakedef.h"
 #include "r_local.h"
 #include "d_local.h"
@@ -126,7 +128,7 @@ D_PolysetDraw(void)
    /* one extra because of cache line pretouching */
 
    a_spans = (spanpackage_t *)
-      (((long)&spans[0] + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
+      (((uintptr_t)&spans[0] + CACHE_SIZE - 1) & ~(uintptr_t)(CACHE_SIZE - 1));
 
    if (r_affinetridesc.drawtype)
       D_DrawSubdiv();

--- a/common/d_scan.c
+++ b/common/d_scan.c
@@ -21,6 +21,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //
 // Portable C scan-level rasterization code, all pixel depths.
 
+#include <stdint.h>
+
 #include "quakedef.h"
 #include "r_local.h"
 #include "d_local.h"
@@ -893,7 +895,7 @@ D_DrawZSpans(espan_t *pspan)
       // we count on FP exceptions being turned off to avoid range problems
       int   izi = (int)(zi * 0x8000 * 0x10000);
 
-      if ((long)pdest & 0x02)
+      if ((int32_t)pdest & 0x02)
       {
          *pdest++ = (short)(izi >> 16);
          izi += izistep;

--- a/common/d_surf.c
+++ b/common/d_surf.c
@@ -19,6 +19,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 // d_surf.c: rasterization driver surface heap manager
 
+#include <stdint.h>
+
 #include "console.h"
 #include "d_local.h"
 #include "quakedef.h"
@@ -144,7 +146,7 @@ D_SCAlloc(int width, int size)
    if ((size <= 0) || (size > 0x10000))
       Sys_Error("%s: bad cache size %d", __func__, size);
 
-   size = (unsigned long)&((surfcache_t *)0)->data[size];
+   size = (uintptr_t)&((surfcache_t *)0)->data[size];
    size = (size + 3) & ~3;
    if (size > sc_size)
       Sys_Error("%s: %i > cache size", __func__, size);

--- a/common/mathlib.c
+++ b/common/mathlib.c
@@ -32,7 +32,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 
 vec3_t vec3_origin = { 0, 0, 0 };
-int nanmask = 255 << 23;
+int32_t nanmask = 255 << 23;
 
 /*-----------------------------------------------------------------*/
 

--- a/common/mathlib.h
+++ b/common/mathlib.h
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define MATHLIB_H
 
 #include <limits.h>
+#include <stdint.h>
 
 #include "qtypes.h"
 
@@ -48,12 +49,12 @@ typedef int fixed16_t;
 #endif
 
 extern vec3_t vec3_origin;
-extern int nanmask;
+extern int32_t nanmask;
 
 #ifdef _MSC_VER
 #define  IS_NAN(x) _isnan(x)
 #else
-#define	IS_NAN(x) (((*(int *)&x)&nanmask)==nanmask)
+#define	IS_NAN(x) (((*(int32_t *)&x)&nanmask)==nanmask)
 #endif
 
 #define DotProduct(x,y) (x[0]*y[0]+x[1]*y[1]+x[2]*y[2])

--- a/common/model.h
+++ b/common/model.h
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 #ifndef MAX_DLIGHTS
 #define MAX_DLIGHTS 32
@@ -297,7 +298,7 @@ typedef struct {
 } maliasframedesc_t;
 
 typedef struct {
-    int firstframe;
+    uintptr_t firstframe;
     int numframes;
 } maliasskindesc_t;
 

--- a/common/net.h
+++ b/common/net.h
@@ -21,6 +21,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifndef NET_H
 #define NET_H
 
+#include <stdint.h>
+
 #include "common.h"
 
 /* net.h -- quake's interface to the networking layer */
@@ -28,7 +30,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 typedef struct {
     union {
 	byte b[4];
-	unsigned l;
+	uint32_t l;
     } ip;
     unsigned short port;
     unsigned short pad;

--- a/common/net_udp.c
+++ b/common/net_udp.c
@@ -303,7 +303,7 @@ UDP_Read(int socket, void *buf, int len, netadr_t *addr)
 static int
 UDP_MakeSocketBroadcastCapable(int socket)
 {
-   int i = 1;
+   char i = 1;
 
    /* make this socket broadcast capable */
    if (setsockopt(socket, SOL_SOCKET, SO_BROADCAST, &i, sizeof(i)) < 0)

--- a/common/r_alias.c
+++ b/common/r_alias.c
@@ -659,7 +659,8 @@ R_AliasSetupSkin
 */
 static void R_AliasSetupSkin(const entity_t *e, aliashdr_t *pahdr)
 {
-   int frame, numframes, skinbytes;
+   uintptr_t frame;
+   int numframes, skinbytes;
    maliasskindesc_t *pskindesc;
    byte *pdata;
    int skinnum = e->skinnum;
@@ -873,7 +874,7 @@ void R_AliasDrawModel(entity_t *e, alight_t *plighting)
 
    // cache align
    pfinalverts = (finalvert_t *)
-			(((long)&finalverts[0] + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
+			(((uintptr_t)&finalverts[0] + CACHE_SIZE - 1) & ~(uintptr_t)(CACHE_SIZE - 1));
    pauxverts = &auxverts[0];
 
    pahdr = (aliashdr_t*)Mod_Extradata(e->model);

--- a/common/r_edge.c
+++ b/common/r_edge.c
@@ -19,6 +19,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 // r_edge.c
 
+#include <stdint.h>
+
 #include "quakedef.h"
 #include "r_local.h"
 #include "sound.h"
@@ -565,10 +567,10 @@ void R_ScanEdges(void)
    espan_t *basespans;
    espan_t *basespan_p;
    surf_t *s;
-   
+
    basespans = malloc(sizeof(espan_t)*CACHE_PAD_ARRAY(MAXSPANS, espan_t));
    basespan_p = (espan_t *)
-			((long)(basespans + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
+			((uintptr_t)(basespans + CACHE_SIZE - 1) & ~(uintptr_t)(CACHE_SIZE - 1));
    max_span_p = &basespan_p[MAXSPANS - r_refdef.vrect.width];
 
    span_p = basespan_p;

--- a/common/r_main.c
+++ b/common/r_main.c
@@ -1004,13 +1004,11 @@ static void R_EdgeDrawing(void)
    if (auxedges) {
       r_edges = auxedges;
    } else {
-      r_edges =  (edge_t *)
-				(((long)&ledges[0] + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
+      r_edges =  (edge_t *)(((uintptr_t)&ledges[0] + CACHE_SIZE - 1) & ~(uintptr_t)(CACHE_SIZE - 1));
    }
 
    if (r_surfsonstack) {
-      surfaces =  (surf_t *)
-				(((long)&lsurfs[0] + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
+      surfaces =  (surf_t *)(((uintptr_t)&lsurfs[0] + CACHE_SIZE - 1) & ~(uintptr_t)(CACHE_SIZE - 1));
       surf_max = &surfaces[r_cnumsurfs];
       // surface 0 doesn't really exist; it's just a dummy because index 0
       // is used to indicate no edge attached to surface

--- a/common/r_part.c
+++ b/common/r_part.c
@@ -83,7 +83,7 @@ float timescale = 0.01;
 
 void R_EntityParticles(const entity_t *ent)
 {
-   int i;
+   int i, j;
    particle_t *p;
    float angle;
    float sp, sy, cp, cy;
@@ -92,8 +92,9 @@ void R_EntityParticles(const entity_t *ent)
 
    if (!avelocities[0][0])
    {
-      for (i = 0; i < NUMVERTEXNORMALS * 3; i++)
-         avelocities[0][i] = (rand() & 255) * 0.01;
+      for (i = 0; i < NUMVERTEXNORMALS; i++)
+         for (j = 0; j < 3; j++)
+            avelocities[i][j] = (rand() & 255) * 0.01;
    }
 
    for (i = 0; i < NUMVERTEXNORMALS; i++) {

--- a/common/r_surf.c
+++ b/common/r_surf.c
@@ -19,6 +19,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 // r_surf.c: surface-related refresh code
 
+#include <stdint.h>
+
 #include "quakedef.h"
 #include "r_local.h"
 #include "sys.h"
@@ -167,7 +169,7 @@ static void R_AddDynamicLightsRGB(void)
    int smax, tmax;
    mtexinfo_t *tex;
    float		cred, cgreen, cblue, brightness;
-   unsigned	*bl;
+   int *bl;
 
    surf = r_drawsurf.surf;
    smax = (surf->extents[0] >> 4) + 1;
@@ -974,7 +976,7 @@ void R_DrawSurfaceBlock16(void)
       pbasesource += sourcetstep;
       lightright += lightrightstep;
       lightleft += lightleftstep;
-      prowdest = (unsigned short *)((long)prowdest + surfrowbytes);
+      prowdest = (unsigned short *)((uintptr_t)prowdest + surfrowbytes);
    }
 
    prowdestbase = prowdest;


### PR DESCRIPTION
As reported here: https://github.com/libretro/tyrquake/pull/108#issuecomment-954777618, the core segfaults under some circumstances when running the shareware version of Quake on Windows.

It turns out that the code makes a number of assumptions about the width of certain data types when casting pointers, which are not true on a number of platforms. On 64bit Windows this can cause pointer addresses to be determined incorrectly - leading to chaos.

This PR fixes the issue by using standard fixed-width types for the affected pointer casts. It also cleans up some other related compiler warnings. 