### PR TITLE
Fix core options version detection

### DIFF
--- a/common/libretro_core_options.h
+++ b/common/libretro_core_options.h
@@ -250,7 +250,7 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
    if (!environ_cb)
       return;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version == 1))
+   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
    {
       struct retro_core_options_intl core_options_intl;
       unsigned language = 0;


### PR DESCRIPTION
On recent versions of RetroArch the core options are currently falling back to v0 format (missing sublabels) due to a trivial 'supported version check' error in `libretro_core_options.h`. This PR fixes the issue.