### PR TITLE
remove stdio includes

### DIFF
--- a/QW/client/quakedef.h
+++ b/QW/client/quakedef.h
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <math.h>
 #include <string.h>
 #include <stdarg.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <setjmp.h>
 #include <time.h>

--- a/QW/qwfwd/qwfwd.c
+++ b/QW/qwfwd/qwfwd.c
@@ -41,7 +41,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *	2 of the License, or (at your option) any later version.
  *
  */
-#include <stdio.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>

--- a/QW/server/qwsvdef.h
+++ b/QW/server/qwsvdef.h
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <math.h>
 #include <string.h>
 #include <stdarg.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <setjmp.h>
 #include <ctype.h>

--- a/common/cd_common.c
+++ b/common/cd_common.c
@@ -20,7 +20,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // Quake is a trademark of Id Software, Inc., (c) 1996 Id Software, Inc. All
 // rights reserved.
 
-#include <stdio.h>
 #include <string.h>
 #include <time.h>
 #include <boolean.h>

--- a/common/cd_linux.c
+++ b/common/cd_linux.c
@@ -20,7 +20,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // Quake is a trademark of Id Software, Inc., (c) 1996 Id Software, Inc. All
 // rights reserved.
 
-#include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>

--- a/common/cl_parse.c
+++ b/common/cl_parse.c
@@ -19,8 +19,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 // cl_parse.c  -- parse a message received from the server
 
-#include <stdio.h>
-
 #include "cdaudio.h"
 #include "client.h"
 #include "cmd.h"

--- a/common/common.c
+++ b/common/common.c
@@ -20,7 +20,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 */
 // common.c -- misc functions used in client and server
-#include <stdio.h>
 #include <ctype.h>
 #include <retro_dirent.h>
 #include <stdarg.h>

--- a/common/common.h
+++ b/common/common.h
@@ -23,7 +23,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define COMMON_H
 
 #include <stdarg.h>
-#include <stdio.h>
 #include <retro_inline.h>
 #include <streams/file_stream.h>
 

--- a/common/quakedef.h
+++ b/common/quakedef.h
@@ -27,7 +27,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <math.h>
 #include <string.h>
 #include <stdarg.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <setjmp.h>
 

--- a/common/shell.c
+++ b/common/shell.c
@@ -22,7 +22,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
 #include <assert.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/common/spritegn.h
+++ b/common/spritegn.h
@@ -49,7 +49,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef INCLUDELIBS
 
 #include <stdlib.h>
-#include <stdio.h>
 #include <math.h>
 #include <string.h>
 


### PR DESCRIPTION
On some systems, including stdio.h can add quite a bit to the binary size. This include is now unnecessary either way.