### PR TITLE
Fix memory leaks

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -1645,7 +1645,7 @@ of the list so they override previous pack files.
 static pack_t *COM_LoadPackFile(const char *packfile)
 {
    int mark;
-   RFILE *packhandle;
+   RFILE *packhandle = NULL;
    dpackheader_t header;
    dpackfile_t *dfiles;
    packfile_t *mfiles;
@@ -1728,10 +1728,13 @@ static pack_t *COM_LoadPackFile(const char *packfile)
    pack->files = mfiles;
 
    Con_Printf("Added packfile %s (%i files)\n", packfile, numfiles);
+   rfclose(packhandle);
 
    return pack;
 
 error:
+   if (packhandle)
+      rfclose(packhandle);
    return NULL;
 }
 

--- a/common/d_sprite.c
+++ b/common/d_sprite.c
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 static int sprite_height;
 static int minindex, maxindex;
-static sspan_t *sprite_spans;
 
 /*
 =====================
@@ -188,11 +187,10 @@ D_SpriteScanLeftEdge
 =====================
 */
 void
-D_SpriteScanLeftEdge(void)
+D_SpriteScanLeftEdge(sspan_t * pspan)
 {
    int lmaxindex;
    float vtop;
-   sspan_t *pspan = sprite_spans;
    int i = minindex;
 
    if (i == 0)
@@ -248,10 +246,9 @@ D_SpriteScanRightEdge
 =====================
 */
 void
-D_SpriteScanRightEdge(void)
+D_SpriteScanRightEdge(sspan_t * pspan)
 {
    float vtop;
-   sspan_t *pspan = sprite_spans;
    int          i = minindex;
    float    vvert = r_spritedesc.pverts[i].v;
 
@@ -384,9 +381,7 @@ D_DrawSprite(void)
    int i, nump;
    float ymin, ymax;
    emitpoint_t *pverts;
-   sspan_t		*spans = malloc(sizeof(sspan_t)*MAXHEIGHT+1);
-
-   sprite_spans = spans;
+   sspan_t		*spans = NULL;
 
    // find the top and bottom vertices, and make sure there's at least one scan to
    // draw
@@ -414,6 +409,8 @@ D_DrawSprite(void)
    if (ymin >= ymax)
       return;			// doesn't cross any scans at all
 
+   spans = malloc(sizeof(sspan_t)*MAXHEIGHT+1);
+
    cachewidth = r_spritedesc.pspriteframe->width;
    sprite_height = r_spritedesc.pspriteframe->height;
    cacheblock = (byte *)&r_spritedesc.pspriteframe->rdata[0];
@@ -425,8 +422,8 @@ D_DrawSprite(void)
    pverts[nump] = pverts[0];
 
    D_SpriteCalculateGradients();
-   D_SpriteScanLeftEdge();
-   D_SpriteScanRightEdge();
-   D_SpriteDrawSpans(sprite_spans);
+   D_SpriteScanLeftEdge(spans);
+   D_SpriteScanRightEdge(spans);
+   D_SpriteDrawSpans(spans);
    free(spans);
 }

--- a/common/r_sprite.c
+++ b/common/r_sprite.c
@@ -165,13 +165,15 @@ static void R_SetupAndDrawSprite(void)
    float scale, *pv;
    vec5_t *pverts;
    vec3_t left, up, right, down, transformed, local;
-   emitpoint_t	*outverts = malloc(sizeof(emitpoint_t)*MAXWORKINGVERTS+1);
+   emitpoint_t	*outverts = NULL;
    emitpoint_t *pout;
    float dot = DotProduct(r_spritedesc.vpn, modelorg);
 
    // backface cull
    if (dot >= 0)
       return;
+
+   outverts = malloc(sizeof(emitpoint_t)*MAXWORKINGVERTS+1);
 
    // build the sprite poster in worldspace
    VectorScale(r_spritedesc.vright, r_spritedesc.pspriteframe->right, right);
@@ -212,7 +214,10 @@ static void R_SetupAndDrawSprite(void)
    for (i = 0; i < 4; i++) {
       nump = R_ClipSpriteFace(nump, &view_clipplanes[i]);
       if (nump < 3)
+      {
+         free(outverts);
          return;
+      }
       if (nump >= MAXWORKINGVERTS)
          Sys_Error("%s: too many points", __func__);
    }


### PR DESCRIPTION
This PR fixes three sources of memory leaks in the core:

- A relatively minor one related to loading PAK files (the file handle was always left open)
- Two serious ones in the sprite handling code, which may potentially trigger multiple times per frame (and which were likely to cause crashes on RAM limited platforms...) 