### PR TITLE
Audio improvments + minor fixes

### DIFF
--- a/common/snd_mix.c
+++ b/common/snd_mix.c
@@ -31,7 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 	((x) < (_minval) ? (_minval) :		\
 	 (x) > (_maxval) ? (_maxval) : (x))
 
-#define	PAINTBUFFER_SIZE	4096
+#define	PAINTBUFFER_SIZE	16384
 portable_samplepair_t paintbuffer[PAINTBUFFER_SIZE];
 int		snd_scaletable[32][256];
 int		*snd_p, snd_linear_count;


### PR DESCRIPTION
PR #93 'fixed' audio at low framerates by dynamically reducing the output sample rate (reducing the quality - quite substantially - but at least producing something). It turns out that this was the wrong fix; audio was breaking at low framerates due to a *frontend* (RetroArch) limitation, whereby samples were being discarded due to the audio batch callback being used to send more frames than it could deal with.

This PR reworks the core such that audio is handled in the same way as vitaquake2. Arbitrary numbers of samples per frames are now supported, and usage of the audio batch callback is minimised whenever possible. Consequently, sample rate 'scaling' is no longer required (greatly improving audio quality at low framerates).

In addition, the default audio sample rate has been reduced from 48 kHz to 44.1 kHz, to match the CD audio tracks and improve performance. This is used for all framerates, *apart from* `40`, `72`, `119` and `120`; it was discovered that some internal engine limitation causes distorted SFX at these specific framerates, which is fixed by selecting alternate higher or lower fallback sample rates (48 kHz in the case of 120 fps, 22.05 kHz for the rest).

Finally, the PR fixes two small general bugs:

- The core is now shut down correctly when closing content, removing a memory leak if content is closed while a demo is running
- We now ensure that `dirent_vfs_init()` is called in `retro_set_environment()`