### PR TITLE
Added 384x216 resolution

### DIFF
--- a/common/libretro_core_options.h
+++ b/common/libretro_core_options.h
@@ -39,6 +39,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "360x240",   NULL },
          { "360x400",   NULL },
          { "360x480",   NULL },
+         { "384x216",   NULL },
          { "400x224",   NULL },
          { "400x240",   NULL },
          { "480x272",   NULL },


### PR DESCRIPTION
Added 384x216 resolution, so we can have a fullscreen, pixel-perfect experience at both 1920x1080 (Full HD) and 3840x2160 (4K).

Note: for this to work, the aspect ratio "Full" must be set in Settings -> Video -> Scaling.